### PR TITLE
It is now possible to modify the name of each column for table revisions and history.

### DIFF
--- a/AuditConfiguration.php
+++ b/AuditConfiguration.php
@@ -25,14 +25,19 @@ namespace SimpleThings\EntityAudit;
 
 class AuditConfiguration
 {
-    private $prefix = '';
-    private $suffix = '_audit';
-    private $revisionFieldName = 'rev';
-    private $revisionTypeFieldName = 'revtype';
+    private $tablePrefix = '';
+    private $tableSuffix = '_audit';
     private $revisionTableName = 'revisions';
+    private $revisionIdFieldName = 'id';
+    private $revisionIdFieldType = 'integer';
+    private $revisionTimestampFieldName = 'timestamp';
+    private $revisionUsernameFieldName = 'username';
+    private $revisionSequenceName = 'revisions_seq';
+    private $histRevisionFieldName = 'rev';
+    private $histTypeFieldName = 'revtype';
     private $auditedEntityClasses = array();
     private $currentUsername = '';
-    private $revisionIdFieldType = 'integer';
+
 
     public function getTablePrefix()
     {
@@ -54,26 +59,6 @@ class AuditConfiguration
         $this->suffix = $suffix;
     }
 
-    public function getRevisionFieldName()
-    {
-        return $this->revisionFieldName;
-    }
-
-    public function setRevisionFieldName($revisionFieldName)
-    {
-        $this->revisionFieldName = $revisionFieldName;
-    }
-
-    public function getRevisionTypeFieldName()
-    {
-        return $this->revisionTypeFieldName;
-    }
-
-    public function setRevisionTypeFieldName($revisionTypeFieldName)
-    {
-        $this->revisionTypeFieldName = $revisionTypeFieldName;
-    }
-
     public function getRevisionTableName()
     {
         return $this->revisionTableName;
@@ -93,12 +78,12 @@ class AuditConfiguration
     {
         return new Metadata\MetadataFactory($this->auditedEntityClasses);
     }
-    
+
     public function setCurrentUsername($username)
     {
         $this->currentUsername = $username;
     }
-    
+
     public function getCurrentUsername()
     {
         return $this->currentUsername;
@@ -112,5 +97,65 @@ class AuditConfiguration
     public function getRevisionIdFieldType()
     {
         return $this->revisionIdFieldType;
+    }
+
+    public function setHistRevisionFieldName($histRevisionFieldName)
+    {
+        $this->histRevisionFieldName = $histRevisionFieldName;
+    }
+
+    public function getHistRevisionFieldName()
+    {
+        return $this->histRevisionFieldName;
+    }
+
+    public function setHistTypeFieldName($histTypeFieldName)
+    {
+        $this->histTypeFieldName = $histTypeFieldName;
+    }
+
+    public function getHistTypeFieldName()
+    {
+        return $this->histTypeFieldName;
+    }
+
+    public function setRevisionIdFieldName($revisionIdFieldName)
+    {
+        $this->revisionIdFieldName = $revisionIdFieldName;
+    }
+
+    public function getRevisionIdFieldName()
+    {
+        return $this->revisionIdFieldName;
+    }
+
+    public function setRevisionSequenceName($revisionSequenceName)
+    {
+        $this->revisionSequenceName = $revisionSequenceName;
+    }
+
+    public function getRevisionSequenceName()
+    {
+        return $this->revisionSequenceName;
+    }
+
+    public function setRevisionTimestampFieldName($revisionTimestampFieldName)
+    {
+        $this->revisionTimestampFieldName = $revisionTimestampFieldName;
+    }
+
+    public function getRevisionTimestampFieldName()
+    {
+        return $this->revisionTimestampFieldName;
+    }
+
+    public function setRevisionUsernameFieldName($revisionUsernameFieldName)
+    {
+        $this->revisionUsernameFieldName = $revisionUsernameFieldName;
+    }
+
+    public function getRevisionUsernameFieldName()
+    {
+        return $this->revisionUsernameFieldName;
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,10 +18,20 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('table_prefix')->defaultValue('')->end()
                 ->scalarNode('table_suffix')->defaultValue('_audit')->end()
-                ->scalarNode('revision_field_name')->defaultValue('rev')->end()
-                ->scalarNode('revision_type_field_name')->defaultValue('revtype')->end()
+
+                // revisions table
                 ->scalarNode('revision_table_name')->defaultValue('revisions')->end()
+                ->scalarNode('revision_id_field_name')->defaultValue('id')->end()
                 ->scalarNode('revision_id_field_type')->defaultValue('integer')->end()
+                ->scalarNode('revision_timestamp_field_name')->defaultValue('timestamp')->end()
+                ->scalarNode('revision_username_field_name')->defaultValue('username')->end()
+
+                // History table
+                ->scalarNode('hist_revision_field_name')->defaultValue('rev')->end()
+                ->scalarNode('hist_type_field_name')->defaultValue('revtype')->end()
+
+                // sequence name
+                ->scalarNode('revision_sequence_name')->defaultValue('revisions_seq')->end()
             ->end();
         return $builder;
     }

--- a/EventListener/LogRevisionsListener.php
+++ b/EventListener/LogRevisionsListener.php
@@ -46,22 +46,22 @@ class LogRevisionsListener implements EventSubscriber
      * @var Doctrine\DBAL\Connection
      */
     private $conn;
-    
+
     /**
      * @var Doctrine\DBAL\Platforms\AbstractPlatform
      */
     private $platform;
-    
+
     /**
      * @var Doctrine\ORM\EntityManager
      */
     private $em;
-    
+
     /**
      * @var array
      */
     private $insertRevisionSQL = array();
-    
+
     /**
      * @var Doctrine\ORM\UnitOfWork
      */
@@ -127,10 +127,10 @@ class LogRevisionsListener implements EventSubscriber
             $this->saveRevisionEntityData($class, $entityData, 'DEL');
         }
     }
-    
+
     /**
      * get original entity data, including versioned field, if "version" constraint is used
-     * 
+     *
      * @param mixed $entity
      * @return array
      */
@@ -149,11 +149,25 @@ class LogRevisionsListener implements EventSubscriber
     {
         if ($this->revisionId === null) {
             $date = date_create("now")->format($this->platform->getDateTimeFormatString());
-            $this->conn->insert($this->config->getRevisionTableName(), array(
-                'timestamp'     => $date,
-                'username'      => $this->config->getCurrentUsername(),
-            ));
-            $this->revisionId = $this->conn->lastInsertId();
+
+            $insertData = array(
+                $this->config->getRevisionTimestampFieldName() => $date,
+                $this->config->getRevisionUsernameFieldName()  => $this->config->getCurrentUsername(),
+            );
+
+            // Perhaps, we should use change this test for something more precise
+            if ( $this->platform->getName() == 'oracle') {
+                // For Oracle, we do not use trigger and use a sequence
+                $insertData[$this->config->getRevisionIdFieldName()] = (int)$this->conn->fetchColumn(
+                    $this->platform->getSequenceNextValSQL($this->config->getRevisionSequenceName())
+                );
+                $this->conn->insert($this->config->getRevisionTableName(), $insertData);
+                $this->revisionId = $this->conn->lastInsertId($this->config->getRevisionSequenceName());
+            } else {
+                $this->conn->insert($this->config->getRevisionTableName(), $insertData);
+                $this->revisionId = $this->conn->lastInsertId();
+            }
+
         }
         return $this->revisionId;
     }
@@ -163,7 +177,7 @@ class LogRevisionsListener implements EventSubscriber
         if (!isset($this->insertRevisionSQL[$class->name])) {
             $tableName = $this->config->getTablePrefix() . $class->table['name'] . $this->config->getTableSuffix();
             $sql = "INSERT INTO " . $tableName . " (" .
-                    $this->config->getRevisionFieldName() . ", " . $this->config->getRevisionTypeFieldName();
+                    $this->config->getHistRevisionFieldName() . ", " . $this->config->getHistTypeFieldName();
             foreach ($class->fieldNames AS $field) {
                 $sql .= ', ' . $class->getQuotedColumnName($field, $this->platform);
             }

--- a/README.md
+++ b/README.md
@@ -176,6 +176,27 @@ This provides you with a few different routes:
  * simple_things_entity_audit_viewentity_detail -- Displays the data for the specified entity at the specified revision
  * simple_things_entity_audit_compare -- Allows you to compare the changes of an entity between 2 revisions
 
+## Configuration Reference
+
+This following configuration example shows all the configuration defaults :
+
+    # app/config/config.yml
+    simple_things_entity_audit:
+        audited_entities : # see above - collection
+        table_prefix :
+        table_suffix : _audit
+
+        revision_table_name : revisions
+        revision_id_field_name : id
+        revision_id_field_type : integer
+        revision_timestamp_field_name : timestamp
+        revision_username_field_name : username
+
+        hist_type_field_name : revtype
+        hist_revision_field_name : rev
+
+        revision_sequence_name: revision_seq
+
 
 ## TODOS
 

--- a/Resources/config/auditable.xml
+++ b/Resources/config/auditable.xml
@@ -8,10 +8,14 @@
         <parameter key="simplethings.entityaudit.audited_entities" type="collection" />
         <parameter key="simplethings.entityaudit.table_prefix" type="string" />
         <parameter key="simplethings.entityaudit.table_suffix" type="string" />
-        <parameter key="simplethings.entityaudit.revision_field_name" type="string" />
-        <parameter key="simplethings.entityaudit.revision_type_field_name" type="string" />
         <parameter key="simplethings.entityaudit.revision_table_name" type="string" />
+        <parameter key="simplethings.entityaudit.revision_id_field_name" type="string" />
         <parameter key="simplethings.entityaudit.revision_id_field_type" type="string" />
+        <parameter key="simplethings.entityaudit.revision_timestamp_field_name" type="string" />
+        <parameter key="simplethings.entityaudit.revision_username_field_name" type="string" />
+        <parameter key="simplethings.entityaudit.hist_revision_field_name" type="string" />
+        <parameter key="simplethings.entityaudit.hist_type_field_name" type="string" />
+        <parameter key="simplethings.entityaudit.revision_sequence_name" type="string" />
     </parameters>
 
     <services>
@@ -43,17 +47,29 @@
             <call method="setTableSuffix">
                 <argument>%simplethings.entityaudit.table_suffix%</argument>
             </call>
-            <call method="setRevisionFieldName">
-                <argument>%simplethings.entityaudit.revision_field_name%</argument>
-            </call>
-            <call method="setRevisionTypeFieldName">
-                <argument>%simplethings.entityaudit.revision_type_field_name%</argument>
-            </call>
             <call method="setRevisionTableName">
                 <argument>%simplethings.entityaudit.revision_table_name%</argument>
             </call>
+            <call method="setRevisionIdFieldName">
+                <argument>%simplethings.entityaudit.revision_id_field_name%</argument>
+            </call>
             <call method="setRevisionIdFieldType">
                 <argument>%simplethings.entityaudit.revision_id_field_type%</argument>
+            </call>
+            <call method="setRevisionTimestampFieldName">
+                <argument>%simplethings.entityaudit.revision_timestamp_field_name%</argument>
+            </call>
+            <call method="setRevisionUsernameFieldName">
+                <argument>%simplethings.entityaudit.revision_username_field_name%</argument>
+            </call>
+            <call method="setHistRevisionFieldName">
+                <argument>%simplethings.entityaudit.hist_revision_field_name%</argument>
+            </call>
+            <call method="setHistTypeFieldName">
+                <argument>%simplethings.entityaudit.hist_type_field_name%</argument>
+            </call>
+            <call method="setRevisionSequenceName">
+                <argument>%simplethings.entityaudit.revision_sequence_name%</argument>
             </call>
         </service>
 


### PR DESCRIPTION
see config.yml :
    simple_things_entity_audit:
        audited_entities : # see above - collection
        table_prefix :
        table_suffix : _audit

```
    revision_table_name : revisions
    revision_id_field_name : id
    revision_id_field_type : integer
    revision_timestamp_field_name : timestamp
    revision_username_field_name : username

    hist_type_field_name : revtype
    hist_revision_field_name : rev

    revision_sequence_name: revision_seq
```

This version is supposed to be compatible with Oracle (if you use this version : https://github.com/doctrine/dbal/commit/5f837d4a676ecbecdbdf13dfe90f72914775a1fa)
