### PR TITLE
Added support for audit fields that require SQL conversions

### DIFF
--- a/EventListener/LogRevisionsListener.php
+++ b/EventListener/LogRevisionsListener.php
@@ -191,7 +191,6 @@ class LogRevisionsListener implements EventSubscriber
             }
             $sql .= ") VALUES (" . implode(", ", $placeholders) . ")";
             $this->insertRevisionSQL[$class->name] = $sql;
-            $this->insertRevisionSQL[$class->name] = $sql;
         }
         return $this->insertRevisionSQL[$class->name];
     }


### PR DESCRIPTION
Basically reflecting the functionality in `Doctrine\ORM\Persisters\BasicEntityPersister::_getInsertSQL()`, to support queries like `INSERT INTO city (name, population, location) VALUES (?, ?, GeomFromText(?))`
