### PR TITLE
Change upper constraint for doctrine/orm to 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["Persistence", "Database", "Audit"],
     "description": "Audit for Doctrine Entities",
     "require": {
-        "doctrine/orm": ">=2.1.0,<2.3"
+        "doctrine/orm": ">=2.1.0,<2.4"
     },
     "autoload": {
         "psr-0": {"SimpleThings\\EntityAudit": "src/"}


### PR DESCRIPTION
To make the bundle working with the latest development version of ORM.
