### PR TITLE
Composer branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
     },
     "autoload": {
         "psr-0": {"SimpleThings\\EntityAudit": "src/"}
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.x-dev"
+        }
     }
 }
 


### PR DESCRIPTION
Add a branch alias to composer.json per https://igor.io/2013/01/07/composer-versioning.html to allow for more specific inclusion of library than `"simplethings/entitiy-audit": "dev-master"`
