### PR TITLE
Fixes logging removal of proxies

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -208,22 +208,25 @@ class LogRevisionsListener implements EventSubscriber
         $types = array(\PDO::PARAM_INT, \PDO::PARAM_STR);
 
         foreach ($class->fieldNames AS $field) {
-            $params[] = $entityData[$field];
+            $params[] = array_key_exists($field, $entityData) ?
+                $entityData[$field] :
+                null;
             $types[] = $class->fieldMappings[$field]['type'];
         }
 
         foreach ($class->associationMappings AS $field => $assoc) {
             if (($assoc['type'] & ClassMetadata::TO_ONE) > 0 && $assoc['isOwningSide']) {
                 $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
+                $data = array_key_exists($field, $entityData) ?
+                    $entityData[$field] :
+                    null;
 
-                if ($entityData[$field] !== null) {
-                    $relatedId = $this->uow->getEntityIdentifier($entityData[$field]);
+                if ($data !== null) {
+                    $relatedId = $this->uow->getEntityIdentifier($data);
                 }
 
-                $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
-
-                foreach ($assoc['sourceToTargetKeyColumns'] as $sourceColumn => $targetColumn) {
-                    if ($entityData[$field] === null) {
+                foreach ($assoc['sourceToTargetKeyColumns'] as $targetColumn) {
+                    if ($data === null) {
                         $params[] = null;
                         $types[] = \PDO::PARAM_STR;
                     } else {

--- a/src/SimpleThings/EntityAudit/Metadata/MetadataFactory.php
+++ b/src/SimpleThings/EntityAudit/Metadata/MetadataFactory.php
@@ -23,6 +23,8 @@
 
 namespace SimpleThings\EntityAudit\Metadata;
 
+use Doctrine\Common\Util\ClassUtils;
+
 class MetadataFactory
 {
     private $auditedEntities = array();
@@ -34,9 +36,9 @@ class MetadataFactory
 
     public function isAudited($entity)
     {
-        return isset($this->auditedEntities[$entity]);
+        return isset($this->auditedEntities[ClassUtils::getRealClass($entity)]);
     }
-    
+
     public function getAllClassNames()
     {
         return array_flip($this->auditedEntities);


### PR DESCRIPTION
When trying to remove a proxy that has not been initialised, you end up with undefined index errors. I approached fixing this by setting anything not defined as null. It may be better to initialise the proxy but I was unsure if this was appropriate at the point where the LogRevisionListener is running.
