### PR TITLE
Simple support for Single Table Inheritance

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -190,6 +190,12 @@ class LogRevisionsListener implements EventSubscriber
                 }
             }
 
+            if($class->isInheritanceTypeSingleTable())
+            {
+                $sql .= ', ' .  $class->discriminatorColumn['fieldName'];
+                $placeholders[] = '?';
+            }
+
             $sql .= ") VALUES (" . implode(", ", $placeholders) . ")";
             $this->insertRevisionSQL[$class->name] = $sql;
         }
@@ -232,6 +238,12 @@ class LogRevisionsListener implements EventSubscriber
                     }
                 }
             }
+        }
+
+        if($class->isInheritanceTypeSingleTable())
+        {
+            $params[] = $class->discriminatorValue;
+            $types[] = $class->discriminatorColumn['type'];
         }
 
         $this->conn->executeUpdate($this->getInsertRevisionSQL($class), $params, $types);


### PR DESCRIPTION
Fix for missing discriminator value in database.
Fix for trying to create abstract class (parent entity).
Resolve #3.

For use you need to add base class and subclass to `audited_entities`

Limitation:
Can not get list of revisions for parent entity class due problems with creating proper SELECT query and mapping entities to subclasses.
