### PR TITLE
Fixed association vs field mapping conflict. Association always win.

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -173,7 +173,7 @@ class LogRevisionsListener implements EventSubscriber
             $sql = "INSERT INTO " . $tableName . " (" .
                     $this->config->getRevisionFieldName() . ", " . $this->config->getRevisionTypeFieldName();
 
-            $fields = [];
+            $fields = array();
 
             foreach ($class->associationMappings AS $assoc) {
                 if ( ($assoc['type'] & ClassMetadata::TO_ONE) > 0 && $assoc['isOwningSide']) {
@@ -213,7 +213,7 @@ class LogRevisionsListener implements EventSubscriber
         $params = array($this->getRevisionId(), $revType);
         $types = array(\PDO::PARAM_INT, \PDO::PARAM_STR);
 
-        $fields = [];
+        $fields = array();
 
         foreach ($class->associationMappings AS $field => $assoc) {
             if (($assoc['type'] & ClassMetadata::TO_ONE) > 0 && $assoc['isOwningSide']) {


### PR DESCRIPTION
Entity mapping 

``` php
/** @ORM\ManyToOne(targetEntity="UserAudit") */
 private $author;

/** @ORM\Column(name="author_id", type="integer", nullable=true) */
 private $authorId;
```

If you have such kind of mapping (for example for serialization purposes), then saving audited version of this entity fails with DB error (proved for MySQL)

```
SQLSTATE[42000]: Syntax error or access violation: 1110 Column 'author_id' specified twice 
```

That's because bundle generates such SQL:

```
"INSERT INTO ArticleAudit_audit (rev, revtype, id, my_title_column, text, author_id, author_id) VALUES (?, ?, ?, ?, ?, ?, ?)"
```

Notice that "author_id" column repeated twice: once for association and once for ordinary field.

This patch fixes an issue with "association mapping always win" policy. I.e. if we have association and ordinary field with the same names, then ordinary field completelty ignored by bundle.

PS: pitifully I can't write test for this case, because it seems that SQLite allows multiple specification of fields in INSERT statement.   
