### PR TITLE
Respect doctrine datetime type for timestamps

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -149,10 +149,12 @@ class LogRevisionsListener implements EventSubscriber
     private function getRevisionId()
     {
         if ($this->revisionId === null) {
-            $date = date_create("now")->format($this->platform->getDateTimeFormatString());
             $this->conn->insert($this->config->getRevisionTableName(), array(
-                'timestamp'     => $date,
+                'timestamp'     => date_create('now'),
                 'username'      => $this->config->getCurrentUsername(),
+            ), array(
+                Type::DATETIME,
+                Type::STRING
             ));
 
             $sequenceName = $this->platform->supportsSequences()


### PR DESCRIPTION
With this, the timestamp inserts should be platform agnostic, and respect datetime overrides for users that are doing things like UTC/local conversions in and out of the database.

This fixes a serious bug for us, we have a UTC timezone conversion for all datetime types, but the audit revision dates are going in as user local time.
