### PR TITLE
Support for getting a list of all revisions that were made of a specific entity class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Audit for Doctrine Entities",
     "require": {
         "doctrine/dbal": "~2.5",
-        "doctrine/orm": "~2.2"
+        "doctrine/orm": "2.4.*"
     },
     "require-dev": {
         "symfony/framework-bundle": "~2.3",

--- a/tests/SimpleThings/Tests/EntityAudit/CoreTest.php
+++ b/tests/SimpleThings/Tests/EntityAudit/CoreTest.php
@@ -180,6 +180,16 @@ class CoreTest extends BaseTest
         $this->assertEquals(1, $revisions[1]->getRev());
         $this->assertInstanceOf('DateTime', $revisions[1]->getTimestamp());
         $this->assertEquals('beberlei', $revisions[1]->getUsername());
+
+        $revisions = $reader->findRevisionHistory(20, 0, array(get_class($article)));
+        $this->assertEquals(1, count($revisions));
+
+        $revisions = $reader->findRevisionHistory(20, 0, array(get_class($user)));
+        $this->assertEquals(1, count($revisions));
+
+        $revisions = $reader->findRevisionHistory(20, 0, array(get_class($article),get_class($user)));
+        $this->assertEquals(2, count($revisions));
+
     }
 
     public function testFindEntitesChangedAtRevision()


### PR DESCRIPTION
Currently it is not possible to search the revision history for specific audited entities. This will allow you to add a filter with one or more entity classes.
