### PR TITLE
Fix unknown column 'e.0' in 'where clause' on AuditController

### DIFF
--- a/src/SimpleThings/EntityAudit/Controller/AuditController.php
+++ b/src/SimpleThings/EntityAudit/Controller/AuditController.php
@@ -97,8 +97,7 @@ class AuditController extends Controller
      */
     public function viewEntityAction($className, $id)
     {
-        $ids = explode(',', $id);
-        $revisions = $this->getAuditReader()->findRevisions($className, $ids);
+        $revisions = $this->getAuditReader()->findRevisions($className, $id);
 
         return $this->render('SimpleThingsEntityAuditBundle:Audit:view_entity.html.twig', array(
             'id' => $id,
@@ -117,8 +116,7 @@ class AuditController extends Controller
      */
     public function viewDetailAction($className, $id, $rev)
     {
-        $ids = explode(',', $id);
-        $entity = $this->getAuditReader()->find($className, $ids, $rev);
+        $entity = $this->getAuditReader()->find($className, $id, $rev);
 
         $data = $this->getAuditReader()->getEntityValues($className, $entity);
         krsort($data);
@@ -152,8 +150,7 @@ class AuditController extends Controller
             $newRev = $request->query->get('newRev');
         }
 
-        $ids = explode(',', $id);
-        $diff = $this->getAuditReader()->diff($className, $ids, $oldRev, $newRev);
+        $diff = $this->getAuditReader()->diff($className, $id, $oldRev, $newRev);
 
         return $this->render('SimpleThingsEntityAuditBundle:Audit:compare.html.twig', array(
             'className' => $className,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no
| Fixed tickets | #288, #289

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->

`\SimpleThings\EntityAudit\AuditReader::find` expect a string `$id` or an array of id field / value pair.

Example:

```php
$id = 1
```

or 

```php
$id = [
  'id' => 1,
];
```

AuditController use `explode(',', $id);` caused an unexpected 'e.0' where clause generated:

```
An exception occurred while executing 'SELECT e.revtype, e.id AS `id`, e.plus_one AS `plusOne`, e.respondent_id, e.wedding_event_id FROM wedding_event_invite_audit e WHERE e.rev <= ? AND e.0 = ? ORDER BY e.rev DESC' with params ["108", "86"]:

SQLSTATE[42S22]: Column not found: 1054 Unknown column 'e.0' in 'where clause'
```

I believe this controller is most likely for demo purpose only. But it is still worth fixing.