### PR TITLE
GC: clean up the maintained list of extra updates on onClear event (target 1.0)

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -199,6 +199,13 @@ class LogRevisionsListener implements EventSubscriber
                 $this->em->getConnection()->executeQuery($sql, $params, $types);
             }
         }
+        $this->cleanUp();
+    }
+
+    private function cleanUp()
+    {
+        $this->extraUpdates = array();
+        gc_collect_cycles();
     }
 
     public function postPersist(LifecycleEventArgs $eventArgs)

--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -96,7 +96,7 @@ class LogRevisionsListener implements EventSubscriber
 
     public function getSubscribedEvents()
     {
-        return array(Events::onFlush, Events::postPersist, Events::postUpdate, Events::postFlush);
+        return array(Events::onFlush, Events::postPersist, Events::postUpdate, Events::postFlush, Events::onClear);
     }
 
     /**
@@ -199,13 +199,6 @@ class LogRevisionsListener implements EventSubscriber
                 $this->em->getConnection()->executeQuery($sql, $params, $types);
             }
         }
-        $this->cleanUp();
-    }
-
-    private function cleanUp()
-    {
-        $this->extraUpdates = array();
-        gc_collect_cycles();
     }
 
     public function postPersist(LifecycleEventArgs $eventArgs)
@@ -246,6 +239,11 @@ class LogRevisionsListener implements EventSubscriber
 
         $entityData = array_merge($this->getOriginalEntityData($entity), $this->uow->getEntityIdentifier($entity));
         $this->saveRevisionEntityData($class, $entityData, 'UPD');
+    }
+
+    public function onClear()
+    {
+        $this->extraUpdates = array();
     }
 
     public function onFlush(OnFlushEventArgs $eventArgs)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | potentially
| Deprecations? | no
| Has tests?    | no

For long running processes that flush several times during their lifecycle, the `$extraUpdates` list may grow substantially over time. This results in extensive memory being consumed for no good reason.