### PR TITLE
Fix memory leak in LogRevisionsListener.php on post flush

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -199,6 +199,8 @@ class LogRevisionsListener implements EventSubscriber
                 $this->em->getConnection()->executeQuery($sql, $params, $types);
             }
         }
+        
+        $this->extraUpdates = array();
     }
 
     public function postPersist(LifecycleEventArgs $eventArgs)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no

When you update several thousand entities in small batches, the extraUpdates array keeps all the entities. This is unnecessary and a memory leak. By emptying it after the update data is written it removes said memory leak. 
