### PR TITLE
symfony 5 tree builder compatibility

### DIFF
--- a/src/SimpleThings/EntityAudit/DependencyInjection/Configuration.php
+++ b/src/SimpleThings/EntityAudit/DependencyInjection/Configuration.php
@@ -9,8 +9,17 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
-        $builder->root('simple_things_entity_audit')
+        $builder = new TreeBuilder('simple_things_entity_audit');
+
+        if (\method_exists($builder, 'getRootNode')) {
+            // SF 4.3+ compatibility
+            $rootNode = $builder->getRootNode();
+        } else {
+            // Older SF
+            $rootNode = $builder->root('simple_things_entity_audit');
+        }
+
+        $rootNode
             ->children()
                 ->arrayNode('audited_entities')
                     ->prototype('scalar')->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes
| Has tests?    | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

Symfony 5 compatibility

```php
$builder = new TreeBuilder();
$builder->root('simple_things_entity_audit'); 
```
deprecated in Symfony 4.3, to be removed in 5.0 in favor of 
```php
$builder = new TreeBuilder('simple_things_entity_audit');
$builder->getRootNode();
```
