### PR TITLE
Allow to use other connection and entity manager than "default"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,19 @@ simple_things_entity_audit:
         - updated_at
 ```
 
+In order to work with other connection or entity manager than "default", use these settings:
+```yml
+simple_things_entity_audit:
+    connection: custom
+    entity_manager: custom
+```
+
 ### Creating new tables
 
 Call the command below to see the new tables in the update schema queue.
 
 ```bash
-./app/console doctrine:schema:update --dump-sql 
+./app/console doctrine:schema:update --dump-sql
 ```
 
 **Notice**: EntityAudit currently **only** works with a DBAL Connection and EntityManager named **"default"**.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,6 +23,8 @@ class Configuration implements ConfigurationInterface
         $builder = new TreeBuilder('simple_things_entity_audit');
         $builder->getRootNode()
             ->children()
+                ->scalarNode('connection')->defaultValue('default')->end()
+                ->scalarNode('entity_manager')->defaultValue('default')->end()
                 ->arrayNode('audited_entities')
                     ->prototype('scalar')->end()
                 ->end()

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -28,6 +28,8 @@ class SimpleThingsEntityAuditExtension extends Extension
         $loader->load('auditable.xml');
 
         $configurables = [
+            'connection',
+            'entity_manager',
             'audited_entities',
             'table_prefix',
             'table_suffix',

--- a/src/Resources/config/auditable.xml
+++ b/src/Resources/config/auditable.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="simplethings.entityaudit.connection" type="string"/>
+        <parameter key="simplethings.entityaudit.entity_manager" type="string"/>
         <parameter key="simplethings.entityaudit.audited_entities" type="collection"/>
         <parameter key="simplethings.entityaudit.global_ignore_columns" type="collection"/>
         <parameter key="simplethings.entityaudit.table_prefix" type="string"/>
@@ -17,16 +19,21 @@
         <service id="SimpleThings\EntityAudit\AuditManager" alias="simplethings_entityaudit.manager" public="true"/>
         <service id="simplethings_entityaudit.reader" class="SimpleThings\EntityAudit\AuditReader" public="true">
             <factory service="simplethings_entityaudit.manager" method="createAuditReader"/>
-            <argument type="service" id="doctrine.orm.default_entity_manager"/>
+            <argument type="service">
+                <service class="Doctrine\ORM\EntityManager">
+                    <factory service="doctrine" method="getManager"/>
+                    <argument type="string">%simplethings.entityaudit.entity_manager%</argument>
+                </service>
+            </argument>
         </service>
         <service id="SimpleThings\EntityAudit\AuditReader" alias="simplethings_entityaudit.reader"/>
         <service id="simplethings_entityaudit.log_revisions_listener" class="SimpleThings\EntityAudit\EventListener\LogRevisionsListener">
             <argument id="simplethings_entityaudit.manager" type="service"/>
-            <tag name="doctrine.event_subscriber" connection="default"/>
+            <tag name="doctrine.event_subscriber" connection="%simplethings.entityaudit.connection%"/>
         </service>
         <service id="simplethings_entityaudit.create_schema_listener" class="SimpleThings\EntityAudit\EventListener\CreateSchemaListener">
             <argument id="simplethings_entityaudit.manager" type="service"/>
-            <tag name="doctrine.event_subscriber" connection="default"/>
+            <tag name="doctrine.event_subscriber" connection="%simplethings.entityaudit.connection%"/>
         </service>
         <service id="simplethings_entityaudit.username_callable.token_storage" class="SimpleThings\EntityAudit\User\TokenStorageUsernameCallable">
             <argument id="service_container" type="service"/>

--- a/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -26,15 +26,15 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.manager', 0, 'simplethings_entityaudit.config');
 
         $this->assertContainerBuilderHasService('simplethings_entityaudit.reader', 'SimpleThings\EntityAudit\AuditReader');
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.reader', 0, 'doctrine.orm.default_entity_manager');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.reader', 0);
 
         $this->assertContainerBuilderHasService('simplethings_entityaudit.log_revisions_listener', 'SimpleThings\EntityAudit\EventListener\LogRevisionsListener');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.log_revisions_listener', 0, 'simplethings_entityaudit.manager');
-        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_subscriber', ['connection' => 'default']);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_subscriber', ['connection' => '%simplethings.entityaudit.connection%']);
 
         $this->assertContainerBuilderHasService('simplethings_entityaudit.create_schema_listener', 'SimpleThings\EntityAudit\EventListener\CreateSchemaListener');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.create_schema_listener', 0, 'simplethings_entityaudit.manager');
-        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.create_schema_listener', 'doctrine.event_subscriber', ['connection' => 'default']);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.create_schema_listener', 'doctrine.event_subscriber', ['connection' => '%simplethings.entityaudit.connection%']);
 
         $this->assertContainerBuilderHasService('simplethings_entityaudit.username_callable.token_storage', 'SimpleThings\EntityAudit\User\TokenStorageUsernameCallable');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.username_callable.token_storage', 0, 'service_container');
@@ -79,6 +79,8 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
     {
         $this->load([]);
 
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.connection', 'default');
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.entity_manager', 'default');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.audited_entities', []);
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.global_ignore_columns', []);
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.table_prefix', '');
@@ -92,6 +94,8 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
     public function testItSetsConfiguredParameters(): void
     {
         $this->load([
+            'connection' => 'my_custom_connection',
+            'entity_manager' => 'my_custom_entity_manager',
             'audited_entities' => ['Entity1', 'Entity2'],
             'global_ignore_columns' => ['created_at', 'updated_at'],
             'table_prefix' => 'prefix',
@@ -102,6 +106,8 @@ class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCase
             'revision_type_field_name' => 'action',
         ]);
 
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.connection', 'my_custom_connection');
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.entity_manager', 'my_custom_entity_manager');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.audited_entities', ['Entity1', 'Entity2']);
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.global_ignore_columns', ['created_at', 'updated_at']);
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.table_prefix', 'prefix');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow to use other connection and entity manager than "default".
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #140.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `connection` configuration node in order to use a different connection than "default";
- `entity_manager` configuration node in order to use a different entity manager than "default".
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
