### PR TITLE
Fix connection for doctrine event tag

### DIFF
--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -49,5 +49,26 @@ class SimpleThingsEntityAuditExtension extends Extension
                 $container->setAlias('simplethings_entityaudit.'.$key, $service);
             }
         }
+
+        $this->fixConnectionForDoctrineTag($container, [
+            'simplethings_entityaudit.log_revisions_listener',
+            'simplethings_entityaudit.create_schema_listener',
+        ]);
+    }
+
+    private function fixConnectionForDoctrineTag(ContainerBuilder $container, array $definitionNames): void
+    {
+        foreach ($definitionNames as $definitionName) {
+            $definition = $container->getDefinition($definitionName);
+            $definition->clearTag('doctrine.event_subscriber');
+
+            foreach ($definition->getTag('doctrine.event_subscriber') as $id => $attributes) {
+                if (isset($attributes['connection']) && $container->hasParameter($attributes['connection'])) {
+                    $attributes['connection'] = (string) $container->getParameter('simplethings.entityaudit.connection');
+                }
+
+                $definition->addTag('doctrine.event_subscriber', $attributes);
+            }
+        }
     }
 }

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -50,23 +50,23 @@ class SimpleThingsEntityAuditExtension extends Extension
             }
         }
 
-        $this->fixConnectionForDoctrineTag($container, [
+        $this->fixParametersFromDoctrineEventSubscriberTag($container, [
             'simplethings_entityaudit.log_revisions_listener',
             'simplethings_entityaudit.create_schema_listener',
         ]);
     }
 
-    private function fixConnectionForDoctrineTag(ContainerBuilder $container, array $definitionNames): void
+    private function fixParametersFromDoctrineEventSubscriberTag(ContainerBuilder $container, array $definitionNames): void
     {
         foreach ($definitionNames as $definitionName) {
             $definition = $container->getDefinition($definitionName);
+            $tags = $definition->getTag('doctrine.event_subscriber');
             $definition->clearTag('doctrine.event_subscriber');
 
-            foreach ($definition->getTag('doctrine.event_subscriber') as $id => $attributes) {
-                if (isset($attributes['connection']) && $container->hasParameter($attributes['connection'])) {
+            foreach ($tags as $id => $attributes) {
+                if (isset($attributes['connection'])) {
                     $attributes['connection'] = (string) $container->getParameter('simplethings.entityaudit.connection');
                 }
-
                 $definition->addTag('doctrine.event_subscriber', $attributes);
             }
         }

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -63,7 +63,7 @@ class SimpleThingsEntityAuditExtension extends Extension
             $tags = $definition->getTag('doctrine.event_subscriber');
             $definition->clearTag('doctrine.event_subscriber');
 
-            foreach ($tags as $id => $attributes) {
+            foreach ($tags as $attributes) {
                 if (isset($attributes['connection'])) {
                     $attributes['connection'] = (string) $container->getParameter('simplethings.entityaudit.connection');
                 }

--- a/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -117,8 +117,8 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_field_name', 'revision');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_type_field_name', 'action');
 
-        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_subscriber', ['connection' => 'my_custom_entity_manager']);
-        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.create_schema_listener', 'doctrine.event_subscriber', ['connection' => 'my_custom_entity_manager']);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_subscriber', ['connection' => 'my_custom_connection']);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.create_schema_listener', 'doctrine.event_subscriber', ['connection' => 'my_custom_connection']);
     }
 
     protected function getContainerExtensions(): array

--- a/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -30,11 +30,11 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
 
         $this->assertContainerBuilderHasService('simplethings_entityaudit.log_revisions_listener', 'SimpleThings\EntityAudit\EventListener\LogRevisionsListener');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.log_revisions_listener', 0, 'simplethings_entityaudit.manager');
-        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_subscriber', ['connection' => '%simplethings.entityaudit.connection%']);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_subscriber', ['connection' => 'default']);
 
         $this->assertContainerBuilderHasService('simplethings_entityaudit.create_schema_listener', 'SimpleThings\EntityAudit\EventListener\CreateSchemaListener');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.create_schema_listener', 0, 'simplethings_entityaudit.manager');
-        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.create_schema_listener', 'doctrine.event_subscriber', ['connection' => '%simplethings.entityaudit.connection%']);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.create_schema_listener', 'doctrine.event_subscriber', ['connection' => 'default']);
 
         $this->assertContainerBuilderHasService('simplethings_entityaudit.username_callable.token_storage', 'SimpleThings\EntityAudit\User\TokenStorageUsernameCallable');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('simplethings_entityaudit.username_callable.token_storage', 0, 'service_container');
@@ -116,6 +116,9 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_id_field_type', 'guid');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_field_name', 'revision');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_type_field_name', 'action');
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_subscriber', ['connection' => 'my_custom_entity_manager']);
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.create_schema_listener', 'doctrine.event_subscriber', ['connection' => 'my_custom_entity_manager']);
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
After #355 I got some errors like:
```
The Doctrine connection "%simplethings.entityaudit.connection%" referenced   
!!    in service "simplethings_entityaudit.log_revisions_listener" does not exist  
!!    . Available connections names: "default".   
```

It look like doctrine event tag will not convert parameter name into value. This PR will replace this parameter name into value.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Changelog is not needed becouse we do not release #355 yet.

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->