### PR TITLE
Add template for find method

### DIFF
--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -211,6 +211,10 @@ class AuditReader
      * @throws \RuntimeException
      *
      * @return object
+     *
+     * @phpstan-template T of object
+     * @phpstan-param class-string<T> $className
+     * @phpstan-return T|null
      */
     public function find($className, $id, $revision, array $options = [])
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is needed to fix a phpstan issue of DoctrineORMAdminBundle

## Changelog

```markdown
### Added
- Added phpstan annotation for `AuditReader::find()` method
```