### PR TITLE
Improve typehint

### DIFF
--- a/src/ChangedEntity.php
+++ b/src/ChangedEntity.php
@@ -15,12 +15,27 @@ namespace SimpleThings\EntityAudit;
 
 class ChangedEntity
 {
+    /**
+     * @var string
+     */
     private $className;
+
+    /**
+     * @var array
+     */
     private $id;
+
+    /**
+     * @var string
+     */
     private $revType;
+
+    /**
+     * @var object
+     */
     private $entity;
 
-    public function __construct($className, array $id, $revType, $entity)
+    public function __construct(string $className, array $id, string $revType, object $entity)
     {
         $this->className = $className;
         $this->id = $id;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -46,7 +46,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('revision_table_name')->defaultValue('revisions')->end()
                 ->scalarNode('revision_id_field_type')
                     ->defaultValue('integer')
-                    // NEXT_MAJOR: Use validate() instead.
+                    // NEXT_MAJOR: Use enumNode() instead.
                     ->beforeNormalization()
                         ->always(static function ($value) {
                             if (null !== $value && !\in_array($value, self::ALLOWED_REVISION_ID_FIELD_TYPE, true)) {

--- a/src/Exception/AuditException.php
+++ b/src/Exception/AuditException.php
@@ -30,6 +30,9 @@ abstract class AuditException extends \Exception
      */
     protected $revision;
 
+    /**
+     * @param int|string|null $revision
+     */
     public function __construct(?string $className, ?array $id, $revision)
     {
         $this->className = $className;

--- a/src/Exception/AuditException.php
+++ b/src/Exception/AuditException.php
@@ -15,13 +15,22 @@ namespace SimpleThings\EntityAudit\Exception;
 
 abstract class AuditException extends \Exception
 {
+    /**
+     * @var string|null
+     */
     protected $className;
 
+    /**
+     * @var array|null
+     */
     protected $id;
 
+    /**
+     * @var int|string|null
+     */
     protected $revision;
 
-    public function __construct($className, $id, $revision)
+    public function __construct(?string $className, ?array $id, $revision)
     {
         $this->className = $className;
         $this->id = $id;

--- a/src/Exception/AuditedCollectionException.php
+++ b/src/Exception/AuditedCollectionException.php
@@ -15,7 +15,7 @@ namespace SimpleThings\EntityAudit\Exception;
 
 class AuditedCollectionException extends AuditException
 {
-    public function __construct($message)
+    public function __construct(string $message)
     {
         \Exception::__construct($message);
     }

--- a/src/Exception/DeletedException.php
+++ b/src/Exception/DeletedException.php
@@ -15,9 +15,10 @@ namespace SimpleThings\EntityAudit\Exception;
 
 class DeletedException extends AuditException
 {
-    public function __construct($className, $id, $revision)
+    public function __construct(string $className, array $id, $revision)
     {
         parent::__construct($className, $id, $revision);
+
         $this->message = sprintf(
             'Class "%s" entity id "%s" has been removed at revision %s',
             $className,

--- a/src/Exception/InvalidRevisionException.php
+++ b/src/Exception/InvalidRevisionException.php
@@ -18,9 +18,7 @@ class InvalidRevisionException extends AuditException
     public function __construct($revision)
     {
         parent::__construct(null, null, $revision);
-        $this->message = sprintf(
-            'No revision "%s" exists.',
-            $revision
-        );
+
+        $this->message = sprintf('No revision "%s" exists.', $revision);
     }
 }

--- a/src/Exception/NoRevisionFoundException.php
+++ b/src/Exception/NoRevisionFoundException.php
@@ -15,9 +15,10 @@ namespace SimpleThings\EntityAudit\Exception;
 
 class NoRevisionFoundException extends AuditException
 {
-    public function __construct($className, $id, $revision)
+    public function __construct(string $className, array $id, $revision)
     {
         parent::__construct($className, $id, $revision);
+
         $this->message = sprintf(
             'No revision of class "%s" (%s) was found at revision %s or before. The entity did not exist at the specified revision yet.',
             $className,

--- a/src/Exception/NotAuditedException.php
+++ b/src/Exception/NotAuditedException.php
@@ -15,12 +15,10 @@ namespace SimpleThings\EntityAudit\Exception;
 
 class NotAuditedException extends AuditException
 {
-    public function __construct($className)
+    public function __construct(string $className)
     {
         parent::__construct($className, null, null);
-        $this->message = sprintf(
-            'Class "%s" is not audited.',
-            $className
-        );
+
+        $this->message = sprintf('Class "%s" is not audited.', $className);
     }
 }

--- a/src/Revision.php
+++ b/src/Revision.php
@@ -18,11 +18,22 @@ namespace SimpleThings\EntityAudit;
  */
 class Revision
 {
+    /**
+     * @var int|string
+     */
     private $rev;
+
+    /**
+     * @var \DateTime
+     */
     private $timestamp;
+
+    /**
+     * @var string
+     */
     private $username;
 
-    public function __construct($rev, $timestamp, $username)
+    public function __construct($rev, \DateTime $timestamp, string $username)
     {
         $this->rev = $rev;
         $this->timestamp = $timestamp;

--- a/src/Utils/ArrayDiff.php
+++ b/src/Utils/ArrayDiff.php
@@ -20,6 +20,14 @@ namespace SimpleThings\EntityAudit\Utils;
  */
 class ArrayDiff
 {
+    /**
+     * @param array $oldData
+     * @param array $newData
+     *
+     * @return array<string, array<string, mixed>>
+     *
+     * @phpstan-return array<string, array{old: mixed, new: mixed, same: mixed}>
+     */
     public function diff($oldData, $newData)
     {
         $diff = [];


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

The `$revision` param is often restrict to `int` but could work with string too. (and SonataAdmin is using `int|string`).
The `$id` seems to only work with `int|string|array` if I read the code.

I also add some typehint for constructor or Exception/Object we're using.

This will fix some errors from https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1386/checks?check_run_id=2265615169

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Allow `$revisions` param to be a string in `AuditManager` methods.

### Deprecated
- Passing another value than 'string', 'integer', 'smallint', 'bigint' or 'guid' for the `revision_id_field_type` value.
```