### PR TITLE
Allow null value for findRevisionHistory

### DIFF
--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -333,10 +333,12 @@ class AuditReader
     }
 
     /**
+     * NEXT_MAJOR: Change the default value to `null`.
+     *
      * Return a list of all revisions.
      *
-     * @param int $limit
-     * @param int $offset
+     * @param int|null $limit
+     * @param int|null $offset
      *
      * @throws Exception
      *


### PR DESCRIPTION
## Subject

Another issue I get with phpstan of SonataDoctrineORM.

We're passing `null` for the limit and the offset, but it's not allowed by the phpdoc.
Still it works perfectly.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `AuditReader::findRevisionHistory()` phpdoc
```