### PR TITLE
Fix missing space in identifier WHERE clausule if the entity has multiple columns as the primary key

### DIFF
--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -187,7 +187,7 @@ class LogRevisionsListener implements EventSubscriber
 
                     $params[] = $meta->reflFields[$idField]->getValue($entity);
 
-                    $sql .= 'AND '.$columnName.' = ?';
+                    $sql .= ' AND '.$columnName.' = ?';
                 }
 
                 $this->em->getConnection()->executeQuery($sql, $params, $types);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
There is a problem if the entity has multiple columns as the primary key. In this case EntityAuditBundle ends with a SyntaxErrorException. 

`Doctrine\DBAL\Driver\Mysqli\Exception\ConnectionError: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '?AND itemid = ?' at line 1 in /Users/vantomas/Projekty/lms-dev/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/Mysqli/Exception/ConnectionError.php:19`

`Next Doctrine\DBAL\Exception\SyntaxErrorException: An exception occurred while executing 'UPDATE invoicecontents_audit SET docid = ? WHERE rev = ? AND docid = ?AND itemid = ?' with params [343765, 149657, 343765, 1]:`


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's without BC-break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix missing space in identifier WHERE clausule if the entity has multiple columns as the primary key

```
