### PR TITLE
Convert enum to string option

### DIFF
--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace SimpleThings\EntityAudit;
 
 use Doctrine\DBAL\Types\Types;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use SimpleThings\EntityAudit\Exception\ConfigurationNotSetException;
 
 class AuditConfiguration
 {
@@ -27,6 +29,11 @@ class AuditConfiguration
     private $revisionTypeFieldName = 'revtype';
     private $revisionIdFieldType = Types::INTEGER;
     private $usernameCallable;
+    private $convertEnumToString = false;
+    /**
+     * @var null|AbstractPlatform
+     */
+    private $databasePlatform = null;
 
     /**
      * @return AuditConfiguration
@@ -54,71 +61,113 @@ class AuditConfiguration
         return $this->getTablePrefix().$tableName.$this->getTableSuffix();
     }
 
+    /**
+     * @return string
+     */
     public function getTablePrefix()
     {
         return $this->tablePrefix;
     }
 
+    /**
+     * @param string $prefix
+     */
     public function setTablePrefix($prefix): void
     {
         $this->tablePrefix = $prefix;
     }
 
+    /**
+     * @return string
+     */
     public function getTableSuffix()
     {
         return $this->tableSuffix;
     }
 
+    /**
+     * @param string $suffix
+     */
     public function setTableSuffix($suffix): void
     {
         $this->tableSuffix = $suffix;
     }
 
+    /**
+     * @return string
+     */
     public function getRevisionFieldName()
     {
         return $this->revisionFieldName;
     }
 
+    /**
+     * @param string $revisionFieldName
+     */
     public function setRevisionFieldName($revisionFieldName): void
     {
         $this->revisionFieldName = $revisionFieldName;
     }
 
+    /**
+     * @return string
+     */
     public function getRevisionTypeFieldName()
     {
         return $this->revisionTypeFieldName;
     }
 
+    /**
+     * @param string $revisionTypeFieldName
+     */
     public function setRevisionTypeFieldName($revisionTypeFieldName): void
     {
         $this->revisionTypeFieldName = $revisionTypeFieldName;
     }
 
+    /**
+     * @return string
+     */
     public function getRevisionTableName()
     {
         return $this->revisionTableName;
     }
 
+    /**
+     * @param string $revisionTableName
+     */
     public function setRevisionTableName($revisionTableName): void
     {
         $this->revisionTableName = $revisionTableName;
     }
 
+    /**
+     * @param string[] $classes
+     */
     public function setAuditedEntityClasses(array $classes): void
     {
         $this->auditedEntityClasses = $classes;
     }
 
+    /**
+     * @return string[]
+     */
     public function getGlobalIgnoreColumns()
     {
         return $this->globalIgnoreColumns;
     }
 
+    /**
+     * @param string[] $columns
+     */
     public function setGlobalIgnoreColumns(array $columns): void
     {
         $this->globalIgnoreColumns = $columns;
     }
 
+    /**
+     * @return Metadata\MetadataFactory
+     */
     public function createMetadataFactory()
     {
         return new Metadata\MetadataFactory($this->auditedEntityClasses);
@@ -146,6 +195,9 @@ class AuditConfiguration
         return (string) ($callable ? $callable() : '');
     }
 
+    /**
+     * @param callable|null $usernameCallable
+     */
     public function setUsernameCallable($usernameCallable): void
     {
         // php 5.3 compat
@@ -164,13 +216,49 @@ class AuditConfiguration
         return $this->usernameCallable;
     }
 
+    /**
+     * @param string $revisionIdFieldType
+     */
     public function setRevisionIdFieldType($revisionIdFieldType): void
     {
         $this->revisionIdFieldType = $revisionIdFieldType;
     }
 
+    /**
+     * @return string
+     */
     public function getRevisionIdFieldType()
     {
         return $this->revisionIdFieldType;
+    }
+
+    public function setConvertEnumToString(bool $convertEnum): void
+    {
+        $this->convertEnumToString = $convertEnum;
+    }
+
+    public function getConvertEnumToString(): bool
+    {
+        return $this->convertEnumToString;
+    }
+
+    /**
+     * @return null|AbstractPlatform
+     */
+    public function getDatabasePlatform()
+    {
+        if($this->getConvertEnumToString() === true && $this->databasePlatform === null){
+            throw new ConfigurationNotSetException('databasePlatform');
+        }
+
+        return $this->databasePlatform;
+    }
+
+    /**
+     * @param null|AbstractPlatform $databasePlatform
+     */
+    public function setDatabasePlatform($databasePlatform): void
+    {
+        $this->databasePlatform = $databasePlatform;
     }
 }

--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -31,7 +31,7 @@ class AuditConfiguration
     private $usernameCallable;
     private $convertEnumToString = false;
     /**
-     * @var null|AbstractPlatform
+     * @var AbstractPlatform|null
      */
     private $databasePlatform = null;
 
@@ -243,11 +243,11 @@ class AuditConfiguration
     }
 
     /**
-     * @return null|AbstractPlatform
+     * @return AbstractPlatform|null
      */
     public function getDatabasePlatform()
     {
-        if($this->getConvertEnumToString() === true && $this->databasePlatform === null){
+        if (true === $this->getConvertEnumToString() && null === $this->databasePlatform) {
             throw new ConfigurationNotSetException('databasePlatform');
         }
 
@@ -255,7 +255,7 @@ class AuditConfiguration
     }
 
     /**
-     * @param null|AbstractPlatform $databasePlatform
+     * @param AbstractPlatform|null $databasePlatform
      */
     public function setDatabasePlatform($databasePlatform): void
     {

--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace SimpleThings\EntityAudit;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use SimpleThings\EntityAudit\Exception\ConfigurationNotSetException;
 

--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -142,7 +142,7 @@ class AuditConfiguration
     }
 
     /**
-     * @param string[] $classes
+     * @phpstan-param class-string[] $classes
      */
     public function setAuditedEntityClasses(array $classes): void
     {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('global_ignore_columns')
                     ->prototype('scalar')->end()
                 ->end()
+                ->scalarNode('convert_enum_to_string')->defaultFalse()->end()
                 ->scalarNode('table_prefix')->defaultValue('')->end()
                 ->scalarNode('table_suffix')->defaultValue('_audit')->end()
                 ->scalarNode('revision_field_name')->defaultValue('rev')->end()

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -39,6 +39,7 @@ class SimpleThingsEntityAuditExtension extends Extension
             'revision_table_name',
             'revision_id_field_type',
             'global_ignore_columns',
+            'convert_enum_to_string',
         ];
 
         foreach ($configurables as $key) {

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -14,14 +14,11 @@ declare(strict_types=1);
 namespace SimpleThings\EntityAudit\EventListener;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\DBAL\Schema\Column;
-use Doctrine\ORM\EntityManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\DBAL\Types\Type;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Doctrine\ORM\Tools\ToolEvents;

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace SimpleThings\EntityAudit\EventListener;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\ORM\EntityManager;
 use Doctrine\DBAL\Schema\Schema;
@@ -22,7 +21,6 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
@@ -90,7 +88,7 @@ class CreateSchemaListener implements EventSubscriber
             $columnArrayOptions = $column->toArray();
 
             // Change Enum type to String.
-            if($this->config->getDatabasePlatform()){
+            if ($this->config->getDatabasePlatform()) {
                 $sqlString = $column->getType()->getSQLDeclaration($columnArrayOptions, $this->config->getDatabasePlatform());
                 if ($this->config->getConvertEnumToString() && false !== strpos($sqlString, 'ENUM')) {
                     $columnTypeName = Types::STRING;

--- a/src/Exception/ConfigurationNotSetException.php
+++ b/src/Exception/ConfigurationNotSetException.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the Sonata Project package.
  *
- * (c) Micheal Mouner <micheal.mouner@gmail.com>
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Exception/ConfigurationNotSetException.php
+++ b/src/Exception/ConfigurationNotSetException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Micheal Mouner <micheal.mouner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SimpleThings\EntityAudit\Exception;
+
+class ConfigurationNotSetException extends \Exception
+{
+    public function __construct(string $configName)
+    {
+        parent::__construct($configName, null, null);
+
+        $this->message = sprintf('Config "%s" must be set.', $configName);
+    }
+}

--- a/src/Resources/config/auditable.php
+++ b/src/Resources/config/auditable.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\EntityManager;
 use SimpleThings\EntityAudit\AuditConfiguration;
 use SimpleThings\EntityAudit\AuditManager;
@@ -74,7 +73,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->call('setConvertEnumToString', ['%simplethings.entityaudit.convert_enum_to_string%'])
             ->call('setDatabasePlatform', [
                 (new InlineServiceConfigurator(new Definition(Connection::class)))
-                    ->factory([new ReferenceConfigurator(Connection::class), 'getDatabasePlatform'])
+                    ->factory([new ReferenceConfigurator(Connection::class), 'getDatabasePlatform']),
             ])
             ->call('setTablePrefix', ['%simplethings.entityaudit.table_prefix%'])
             ->call('setTableSuffix', ['%simplethings.entityaudit.table_suffix%'])

--- a/src/Resources/config/auditable.php
+++ b/src/Resources/config/auditable.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\EntityManager;
 use SimpleThings\EntityAudit\AuditConfiguration;
 use SimpleThings\EntityAudit\AuditManager;
@@ -69,6 +71,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->public()
             ->call('setAuditedEntityClasses', ['%simplethings.entityaudit.audited_entities%'])
             ->call('setGlobalIgnoreColumns', ['%simplethings.entityaudit.global_ignore_columns%'])
+            ->call('setConvertEnumToString', ['%simplethings.entityaudit.convert_enum_to_string%'])
+            ->call('setDatabasePlatform', [
+                (new InlineServiceConfigurator(new Definition(Connection::class)))
+                    ->factory([new ReferenceConfigurator(Connection::class), 'getDatabasePlatform'])
+            ])
             ->call('setTablePrefix', ['%simplethings.entityaudit.table_prefix%'])
             ->call('setTableSuffix', ['%simplethings.entityaudit.table_suffix%'])
             ->call('setRevisionTableName', ['%simplethings.entityaudit.revision_table_name%'])

--- a/src/Utils/SimpleDiff.php
+++ b/src/Utils/SimpleDiff.php
@@ -50,6 +50,8 @@ class SimpleDiff
     {
         $ret = '';
         $diff = $this->diff(explode(' ', $old), explode(' ', $new));
+        $nmax = 0;
+        $omax = 0;
         foreach ($diff as $k) {
             if (\is_array($k)) {
                 $ret .= (!empty($k['d']) ? '<del>'.implode(' ', $k['d']).'</del> ' : '').

--- a/src/Utils/SimpleDiff.php
+++ b/src/Utils/SimpleDiff.php
@@ -50,8 +50,6 @@ class SimpleDiff
     {
         $ret = '';
         $diff = $this->diff(explode(' ', $old), explode(' ', $new));
-        $nmax = 0;
-        $omax = 0;
         foreach ($diff as $k) {
             if (\is_array($k)) {
                 $ret .= (!empty($k['d']) ? '<del>'.implode(' ', $k['d']).'</del> ' : '').

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -145,6 +145,8 @@ abstract class BaseTest extends TestCase
         }
 
         $auditConfig = AuditConfiguration::forEntities($this->auditedEntities);
+        $auditConfig->setConvertEnumToString(true);
+        $auditConfig->setDatabasePlatform($this->getEntityManager()->getConnection()->getDatabasePlatform());
         $auditConfig->setGlobalIgnoreColumns(['ignoreme']);
         $auditConfig->setUsernameCallable(static function () {
             return 'beberlei';


### PR DESCRIPTION
## Subject

I am targeting this branch, because I need to add a new features to the bundle
I added a boolean option to convert EnumToString incase you are using it in the DB (it causes problems)
```
convert_enum_to_string: true # default to false
```

example of created ENUM migration
```
$this->addSql('ALTER TABLE table_name ADD enum_column ENUM(\'option_1\', \'option_2\', \'option_3\') DEFAULT \'option_3\' NOT NULL');
$this->addSql('ALTER TABLE table_name ADD enum_column VARCHAR(255) DEFAULT \'option_3\'');
```

## Changelog

```markdown
### Added
two new options:
- convert_enum_to_string --> if true, it will convert Enum value to string in audit table

### Fixed
src/SimpleThings/EntityAudit/Utils/SimpleDiff.php:26 --> fix undefined variable

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
