### PR TITLE
Bump doctrine/orm to 2.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,19 +11,21 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "doctrine/dbal": "^2.11",
-        "doctrine/orm": "^2.7",
+        "doctrine/orm": "^2.9",
         "symfony/config": "^4.4 || ^5.2",
         "twig/twig": "^2.6 || ^3.0"
     },
     "conflict": {
         "doctrine/doctrine-bundle": "<1.4",
         "gedmo/doctrine-extensions": "<2.3.1",
-        "symfony/framework-bundle": "<2.7"
+        "symfony/framework-bundle": "<4.4"
     },
     "require-dev": {
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/doctrine-bundle": "^1.4 || ^2.2",
         "gedmo/doctrine-extensions": "^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2.1",
+        "symfony/cache": "^4.4 || ^5.2",
         "symfony/framework-bundle": "^4.4 || ^5.2",
         "symfony/phpunit-bridge": "^5.2",
         "symfony/var-dumper": "^4.4 || ^5.2"

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace SimpleThings\EntityAudit\Tests;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Types\Type;
@@ -25,6 +25,7 @@ use Gedmo;
 use PHPUnit\Framework\TestCase;
 use SimpleThings\EntityAudit\AuditConfiguration;
 use SimpleThings\EntityAudit\AuditManager;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 abstract class BaseTest extends TestCase
 {
@@ -72,8 +73,8 @@ abstract class BaseTest extends TestCase
         }
 
         $config = new Configuration();
-        $config->setMetadataCacheImpl(new ArrayCache());
-        $config->setQueryCacheImpl(new ArrayCache());
+        $config->setMetadataCache(new ArrayAdapter());
+        $config->setQueryCacheImpl(DoctrineProvider::wrap(new ArrayAdapter()));
         $config->setProxyDir(__DIR__.'/Proxies');
         $config->setAutoGenerateProxyClasses(ProxyFactory::AUTOGENERATE_EVAL);
         $config->setProxyNamespace('SimpleThings\EntityAudit\Tests\Proxies');


### PR DESCRIPTION
Bumping to 2.9 allows compatibility with `doctrine/cache` 2.