### PR TITLE
Fix: Compare Action route

### DIFF
--- a/src/Action/CompareAction.php
+++ b/src/Action/CompareAction.php
@@ -46,8 +46,7 @@ final class CompareAction
             $newRev = $request->query->get('newRev');
         }
 
-        $ids = explode(',', $id);
-        $diff = $this->auditReader->diff($className, $ids, $oldRev, $newRev);
+        $diff = $this->auditReader->diff($className, $id, $oldRev, $newRev);
 
         $content = $this->twig->render('@SimpleThingsEntityAudit/Audit/compare.html.twig', [
             'className' => $className,

--- a/src/Action/ViewDetailAction.php
+++ b/src/Action/ViewDetailAction.php
@@ -37,8 +37,7 @@ final class ViewDetailAction
 
     public function __invoke(string $className, string $id, int $rev): Response
     {
-        $ids = explode(',', $id);
-        $entity = $this->auditReader->find($className, $ids, $rev);
+        $entity = $this->auditReader->find($className, $id, $rev);
 
         $data = $this->auditReader->getEntityValues($className, $entity);
         krsort($data);

--- a/src/Action/ViewEntityAction.php
+++ b/src/Action/ViewEntityAction.php
@@ -37,8 +37,7 @@ final class ViewEntityAction
 
     public function __invoke(string $className, string $id): Response
     {
-        $ids = explode(',', $id);
-        $revisions = $this->auditReader->findRevisions($className, $ids);
+        $revisions = $this->auditReader->findRevisions($className, $id);
 
         $content = $this->twig->render('@SimpleThingsEntityAudit/Audit/view_entity.html.twig', [
             'id' => $id,

--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -613,10 +613,10 @@ class AuditReader
      * Get an array with the differences of between two specific revisions of
      * an object with a given id.
      *
-     * @param string           $className
-     * @param int|string       $id
-     * @param int|string       $oldRevision
-     * @param int|string       $newRevision
+     * @param string     $className
+     * @param int|string $id
+     * @param int|string $oldRevision
+     * @param int|string $newRevision
      *
      * @throws DeletedException
      * @throws NoRevisionFoundException

--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -614,7 +614,7 @@ class AuditReader
      * an object with a given id.
      *
      * @param string           $className
-     * @param int|string|array $id
+     * @param int|string       $id
      * @param int|string       $oldRevision
      * @param int|string       $newRevision
      *

--- a/src/Resources/config/routing/audit.xml
+++ b/src/Resources/config/routing/audit.xml
@@ -12,7 +12,7 @@
     </route>
     <route id="simple_things_entity_audit_viewentity" path="/viewent/{className}/{id}" controller="SimpleThings\EntityAudit\Action\ViewEntityAction"/>
     <route id="simple_things_entity_audit_compare" path="/compare/{className}/{id}/{oldRev}/{newRev}" controller="SimpleThings\EntityAudit\Action\CompareAction">
-        <default key="oldRev"/>
-        <default key="newRev"/>
+        <default key="oldRev" xsi:nil="true"/>
+        <default key="newRev" xsi:nil="true"/>
     </route>
 </routes>


### PR DESCRIPTION
## Subject

This fixes the issue where a revision could not be viewing via the `CompareAction` route.

I am targeting the `1.x` branch because it's a bug fix which is backwards compatible.

Closes #405.

## Changelog

```markdown
### Fixed

- The CompareAction route is now working.
```
