### PR TITLE
Add foreign key constraint for the relation between the entity audit tables and the revisions index

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,2 +1,13 @@
 UPGRADE 1.x
 ===========
+
+UPGRADE FROM 1.x to 1.x
+=======================
+
+### `SimpleThings\EntityAudit\EventListener\CreateSchemaListener`
+
+"postGenerateSchema" event is not listen anymore. The table responsible for storing
+the revisions index is created on the "postGenerateSchemaTable" event.
+A foreign key constraint was added for the relation between the revisions index and
+the audit tables, disallowing to delete the records in the index if their referenced
+values exist in the audit tables.

--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -580,26 +580,26 @@ class AuditReader
             throw new NotAuditedException($className);
         }
 
-        /** @var ClassMetadataInfo|ClassMetadata $class */
-        $class = $this->em->getClassMetadata($className);
-        $tableName = $this->config->getTableName($class);
+        /** @var ClassMetadataInfo|ClassMetadata $classMetadata */
+        $classMetadata = $this->em->getClassMetadata($className);
+        $tableName = $this->config->getTableName($classMetadata);
 
         if (!\is_array($id)) {
-            $id = [$class->identifier[0] => $id];
+            $id = [$classMetadata->identifier[0] => $id];
         }
 
         $whereSQL = '';
-        foreach ($class->identifier as $idField) {
-            if (isset($class->fieldMappings[$idField])) {
+        foreach ($classMetadata->identifier as $idField) {
+            if (isset($classMetadata->fieldMappings[$idField])) {
                 if ($whereSQL) {
                     $whereSQL .= ' AND ';
                 }
-                $whereSQL .= 'e.'.$class->fieldMappings[$idField]['columnName'].' = ?';
-            } elseif (isset($class->associationMappings[$idField])) {
+                $whereSQL .= 'e.'.$classMetadata->fieldMappings[$idField]['columnName'].' = ?';
+            } elseif (isset($classMetadata->associationMappings[$idField])) {
                 if ($whereSQL) {
                     $whereSQL .= ' AND ';
                 }
-                $whereSQL .= 'e.'.$class->associationMappings[$idField]['joinColumns'][0].' = ?';
+                $whereSQL .= 'e.'.$classMetadata->associationMappings[$idField]['joinColumns'][0].' = ?';
             }
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add foreign key constraint for the relation between the entity audit tables and the revisions index.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Foreign key constraint for the relation between the entity audit tables and the revisions index.

### Removed
- Listening for the "postGenerateSchema" event at `CreateSchemaListener`.

### Deprecated
- `CreateSchemaListener::postGenerateSchema()` method.

### Fixed
- Orphan records between the entity audit tables and the revisions index.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Update the tests;
- [x] Add an upgrade note.

