### PR TITLE
Remove obsolete condition and make `AuditedCollection` compatible with `Collection`

### DIFF
--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -836,11 +836,6 @@ class AuditReader
         }
 
         foreach ($class->associationMappings as $field => $assoc) {
-            // Check if the association is not among the fetch-joined associations already.
-            if (isset($hints['fetched'][$className][$field])) {
-                continue;
-            }
-
             /** @var ClassMetadataInfo|ClassMetadata $targetClass */
             $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
 

--- a/src/Collection/AuditedCollection.php
+++ b/src/Collection/AuditedCollection.php
@@ -33,13 +33,15 @@ class AuditedCollection implements Collection
      * Class to fetch.
      *
      * @var string
+     *
+     * @phpstan-var class-string
      */
     protected $class;
 
     /**
      * Foreign keys for target entity.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $foreignKeys;
 
@@ -66,14 +68,16 @@ class AuditedCollection implements Collection
      * - store entity
      * - contain audited entity.
      *
-     * @var ArrayCollection
+     * @var ArrayCollection<int|string, object|array<string, mixed>>
+     *
+     * @phpstan-var ArrayCollection<array-key, object|array<string, mixed>>
      */
     protected $entities;
 
     /**
      * Definition of current association.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $associationDefinition = [];
 
@@ -82,6 +86,13 @@ class AuditedCollection implements Collection
      */
     protected $initialized = false;
 
+    /**
+     * @param string               $class
+     * @param array<string, mixed> $associationDefinition
+     * @param array<string, mixed> $foreignKeys
+     *
+     * @phpstan-param class-string $class
+     */
     public function __construct(AuditReader $auditReader, $class, ClassMetadataInfo $classMeta, array $associationDefinition, array $foreignKeys, $revision)
     {
         $this->auditReader = $auditReader;
@@ -94,26 +105,17 @@ class AuditedCollection implements Collection
         $this->entities = new ArrayCollection();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function add($element)
     {
         throw new AuditedCollectionException('The AuditedCollection is read-only');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function clear(): void
     {
         $this->entities = new ArrayCollection();
         $this->initialized = false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function contains($element)
     {
         $this->forceLoad();
@@ -121,9 +123,6 @@ class AuditedCollection implements Collection
         return $this->entities->contains($element);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isEmpty()
     {
         $this->initialize();
@@ -131,25 +130,16 @@ class AuditedCollection implements Collection
         return $this->entities->isEmpty();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function remove($key)
     {
         throw new AuditedCollectionException('Audited collections does not support removal');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function removeElement($element)
     {
         throw new AuditedCollectionException('Audited collections does not support removal');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function containsKey($key)
     {
         $this->initialize();
@@ -157,17 +147,11 @@ class AuditedCollection implements Collection
         return $this->entities->containsKey($key);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function get($key)
     {
         return $this->offsetGet($key);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getKeys()
     {
         $this->initialize();
@@ -175,9 +159,6 @@ class AuditedCollection implements Collection
         return $this->entities->getKeys();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getValues()
     {
         $this->forceLoad();
@@ -185,17 +166,11 @@ class AuditedCollection implements Collection
         return $this->entities->getValues();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function set($key, $value): void
     {
         throw new AuditedCollectionException('AuditedCollection is read-only');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function toArray()
     {
         $this->forceLoad();
@@ -203,9 +178,6 @@ class AuditedCollection implements Collection
         return $this->entities->toArray();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function first()
     {
         $this->forceLoad();
@@ -213,9 +185,6 @@ class AuditedCollection implements Collection
         return $this->entities->first();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function last()
     {
         $this->forceLoad();
@@ -223,9 +192,6 @@ class AuditedCollection implements Collection
         return $this->entities->last();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function key()
     {
         $this->forceLoad();
@@ -233,9 +199,6 @@ class AuditedCollection implements Collection
         return $this->entities->key();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function current()
     {
         $this->forceLoad();
@@ -243,9 +206,6 @@ class AuditedCollection implements Collection
         return $this->entities->current();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function next()
     {
         $this->forceLoad();
@@ -253,9 +213,6 @@ class AuditedCollection implements Collection
         return $this->entities->next();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function exists(\Closure $p)
     {
         $this->forceLoad();
@@ -263,9 +220,6 @@ class AuditedCollection implements Collection
         return $this->entities->exists($p);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function filter(\Closure $p)
     {
         $this->forceLoad();
@@ -273,9 +227,6 @@ class AuditedCollection implements Collection
         return $this->entities->filter($p);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function forAll(\Closure $p)
     {
         $this->forceLoad();
@@ -283,9 +234,6 @@ class AuditedCollection implements Collection
         return $this->entities->forAll($p);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function map(\Closure $func)
     {
         $this->forceLoad();
@@ -293,9 +241,6 @@ class AuditedCollection implements Collection
         return $this->entities->map($func);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function partition(\Closure $p)
     {
         $this->forceLoad();
@@ -303,9 +248,6 @@ class AuditedCollection implements Collection
         return $this->entities->partition($p);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function indexOf($element)
     {
         $this->forceLoad();
@@ -313,9 +255,6 @@ class AuditedCollection implements Collection
         return $this->entities->indexOf($element);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function slice($offset, $length = null)
     {
         $this->forceLoad();
@@ -323,9 +262,6 @@ class AuditedCollection implements Collection
         return $this->entities->slice($offset, $length);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getIterator()
     {
         $this->forceLoad();
@@ -333,9 +269,6 @@ class AuditedCollection implements Collection
         return $this->entities->getIterator();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function offsetExists($offset)
     {
         $this->forceLoad();
@@ -343,9 +276,6 @@ class AuditedCollection implements Collection
         return $this->entities->offsetExists($offset);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function offsetGet($offset)
     {
         $this->initialize();
@@ -366,25 +296,16 @@ class AuditedCollection implements Collection
         return $resolvedEntity;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function offsetSet($offset, $value): void
     {
         throw new AuditedCollectionException('AuditedCollection is read-only');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function offsetUnset($offset): void
     {
         throw new AuditedCollectionException('Audited collections does not support removal');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function count()
     {
         $this->initialize();

--- a/src/Collection/AuditedCollection.php
+++ b/src/Collection/AuditedCollection.php
@@ -97,7 +97,7 @@ class AuditedCollection implements Collection
     /**
      * {@inheritdoc}
      */
-    public function add($element): void
+    public function add($element)
     {
         throw new AuditedCollectionException('The AuditedCollection is read-only');
     }
@@ -134,7 +134,7 @@ class AuditedCollection implements Collection
     /**
      * {@inheritdoc}
      */
-    public function remove($key): void
+    public function remove($key)
     {
         throw new AuditedCollectionException('Audited collections does not support removal');
     }
@@ -142,7 +142,7 @@ class AuditedCollection implements Collection
     /**
      * {@inheritdoc}
      */
-    public function removeElement($element): void
+    public function removeElement($element)
     {
         throw new AuditedCollectionException('Audited collections does not support removal');
     }

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -17,9 +17,9 @@ class MetadataFactory
 {
     private $auditedEntities = [];
 
-    public function __construct($auditedEntities)
+    public function __construct(array $auditedEntities)
     {
-        $this->auditedEntities = array_flip(array_filter($auditedEntities, static function ($record) {
+        $this->auditedEntities = array_flip(array_filter($auditedEntities, static function ($record): bool {
             return \is_string($record) || \is_int($record);
         }));
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Remove obsolete condition (0bee5782dbbe54fd2e5b58d744e0647e16b548d9) and make `AuditedCollection` compatible with `Collection`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Wrong return type declarations in `AuditedCollection` methods;
- Obsolete check in `AuditReader::createEntity()`.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
