### PR TITLE
Catch `InvalidRevisionException` at `ViewRevisionAction::__invoke()`

### DIFF
--- a/src/Action/ViewRevisionAction.php
+++ b/src/Action/ViewRevisionAction.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SimpleThings\EntityAudit\Action;
 
 use SimpleThings\EntityAudit\AuditReader;
+use SimpleThings\EntityAudit\Exception\InvalidRevisionException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Twig\Environment;
@@ -36,11 +37,15 @@ final class ViewRevisionAction
         $this->auditReader = $auditReader;
     }
 
+    /**
+     * @throws NotFoundHttpException
+     */
     public function __invoke(int $rev): Response
     {
-        $revision = $this->auditReader->findRevision($rev);
-        if (!$revision) {
-            throw new NotFoundHttpException(sprintf('Revision %i not found', $rev));
+        try {
+            $revision = $this->auditReader->findRevision($rev);
+        } catch (InvalidRevisionException $ex) {
+            throw new NotFoundHttpException(sprintf('Revision %d not found', $rev), $ex);
         }
 
         $changedEntities = $this->auditReader->findEntitiesChangedAtRevision($rev);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Catch `InvalidRevisionException` at `ViewRevisionAction::__invoke()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Bug discovered in #413.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `InvalidRevisionException` exception handling when a revision is not found at `ViewRevisionAction::__invoke()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
