### PR TITLE
Fixed join columns to be converted to the correct type

### DIFF
--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -888,7 +888,10 @@ class AuditReader
                             foreach ($assoc['targetToSourceKeyColumns'] as $targetColumn => $srcColumn) {
                                 $joinColumnValue = $data[$columnMap[$srcColumn]] ?? null;
                                 if (null !== $joinColumnValue) {
-                                    $associatedId[$targetClass->fieldNames[$targetColumn]] = $joinColumnValue;
+                                    $targetField = $targetClass->fieldNames[$targetColumn];
+                                    $joinColumnType = Type::getType($targetClass->fieldMappings[$targetField]['type']);
+                                    $joinColumnValue = $type->convertToPHPValue($joinColumnValue, $this->platform);
+                                    $associatedId[$targetField] = $joinColumnValue;
                                 }
                             }
                             if (!$associatedId) {

--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -890,7 +890,7 @@ class AuditReader
                                 if (null !== $joinColumnValue) {
                                     $targetField = $targetClass->fieldNames[$targetColumn];
                                     $joinColumnType = Type::getType($targetClass->fieldMappings[$targetField]['type']);
-                                    $joinColumnValue = $type->convertToPHPValue($joinColumnValue, $this->platform);
+                                    $joinColumnValue = $joinColumnType->convertToPHPValue($joinColumnValue, $this->platform);
                                     $associatedId[$targetField] = $joinColumnValue;
                                 }
                             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Currently, `AuditReader` fails when handling `ToOne` associations with Symfony Uuids as primary keys. This is fixed by converting the join column value with the join column's type as is already done in line 834 for regular fields.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a simple patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed `AuditReader` to process to-many associations using IDs with custom types 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
