### PR TITLE
Match composer license with LICENSE file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "sonata-project/entity-audit-bundle",
     "description": "Audit for Doctrine Entities",
-    "license": "LGPL-2.1",
+    "license": "MIT",
     "type": "symfony-bundle",
     "keywords": [
         "Persistence",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Changing the license configuration of the composer file to match the latest change of the LICENSE file.

I am targeting this branch, because the LICENSE change was introduce int this branch.

It need to be applied to both branch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown


### Changed
- Change composer license to MIT
```

