### PR TITLE
PHPStan level 6 with `AuditReader` not generic

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - src
         - tests
@@ -12,3 +12,5 @@ parameters:
     checkMissingIterableValueType: true
     checkMissingVarTagTypehint: true
     checkMissingTypehints: true
+    ignoreErrors:
+        - '#^Method SimpleThings\\EntityAudit\\Tests\\[a-zA-Z0-9_\\]+Test::(data|provide)[a-zA-Z0-9_]+\(\) return type has no value type specified in iterable type [a-zA-Z0-9_]+\.$#'

--- a/src/Action/CompareAction.php
+++ b/src/Action/CompareAction.php
@@ -36,6 +36,9 @@ final class CompareAction
         $this->auditReader = $auditReader;
     }
 
+    /**
+     * @phpstan-param class-string $className
+     */
     public function __invoke(Request $request, string $className, string $id, ?int $oldRev = null, ?int $newRev = null): Response
     {
         if (null === $oldRev) {

--- a/src/Action/ViewDetailAction.php
+++ b/src/Action/ViewDetailAction.php
@@ -35,6 +35,9 @@ final class ViewDetailAction
         $this->auditReader = $auditReader;
     }
 
+    /**
+     * @phpstan-param class-string $className
+     */
     public function __invoke(string $className, string $id, int $rev): Response
     {
         $entity = $this->auditReader->find($className, $id, $rev);

--- a/src/Action/ViewEntityAction.php
+++ b/src/Action/ViewEntityAction.php
@@ -35,6 +35,9 @@ final class ViewEntityAction
         $this->auditReader = $auditReader;
     }
 
+    /**
+     * @phpstan-param class-string $className
+     */
     public function __invoke(string $className, string $id): Response
     {
         $revisions = $this->auditReader->findRevisions($className, $id);

--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -206,9 +206,10 @@ class AuditReader
      * returns last revision INCLUDING "DEL" revision. If you want to throw exception instead, set
      * $threatDeletionAsException to true.
      *
-     * @param string           $className
-     * @param int|string|array $id
-     * @param int|string       $revision
+     * @param string                                    $className
+     * @param int|string|array<string, int|string>      $id
+     * @param int|string                                $revision
+     * @param array{threatDeletionsAsExceptions?: bool} $options
      *
      * @throws DeletedException
      * @throws NoRevisionFoundException
@@ -377,7 +378,7 @@ class AuditReader
      *
      * @param string|int $revision
      *
-     * @return ChangedEntity[]
+     * @return ChangedEntity<object>[]
      */
     public function findEntitesChangedAtRevision($revision)
     {
@@ -396,7 +397,7 @@ class AuditReader
      * @throws ORMException
      * @throws \RuntimeException
      *
-     * @return ChangedEntity[]
+     * @return ChangedEntity<object>[]
      */
     public function findEntitiesChangedAtRevision($revision)
     {
@@ -508,8 +509,8 @@ class AuditReader
     /**
      * Find all revisions that were made of entity class with given id.
      *
-     * @param string           $className
-     * @param int|string|array $id
+     * @param string                               $className
+     * @param int|string|array<string, int|string> $id
      *
      * @throws NotAuditedException
      * @throws Exception
@@ -566,8 +567,8 @@ class AuditReader
      * NEXT_MAJOR: Add NoRevisionFoundException as possible exception.
      * Gets the current revision of the entity with given ID.
      *
-     * @param string           $className
-     * @param int|string|array $id
+     * @param string                               $className
+     * @param int|string|array<string, int|string> $id
      *
      * @throws NotAuditedException
      * @throws Exception
@@ -677,8 +678,8 @@ class AuditReader
     }
 
     /**
-     * @param string           $className
-     * @param int|string|array $id
+     * @param string                               $className
+     * @param int|string|array<string, int|string> $id
      *
      * @throws DeletedException
      * @throws NoRevisionFoundException
@@ -774,8 +775,10 @@ class AuditReader
     /**
      * Simplified and stolen code from UnitOfWork::createEntity.
      *
-     * @param string     $className
-     * @param int|string $revision
+     * @param string                $className
+     * @param array<string, string> $columnMap
+     * @param array<string, mixed>  $data
+     * @param int|string            $revision
      *
      * @throws DeletedException
      * @throws NoRevisionFoundException

--- a/src/ChangedEntity.php
+++ b/src/ChangedEntity.php
@@ -26,7 +26,7 @@ class ChangedEntity
     private $className;
 
     /**
-     * @var array
+     * @var array<string, int|string>
      */
     private $id;
 
@@ -43,6 +43,8 @@ class ChangedEntity
     private $entity;
 
     /**
+     * @param array<string, int|string> $id
+     *
      * @phpstan-param class-string<T> $className
      * @phpstan-param T $entity
      */
@@ -65,7 +67,7 @@ class ChangedEntity
     }
 
     /**
-     * @return array
+     * @return array<string, int|string>
      */
     public function getId()
     {

--- a/src/Collection/AuditedCollection.php
+++ b/src/Collection/AuditedCollection.php
@@ -30,7 +30,7 @@ class AuditedCollection implements Collection
     /**
      * Related audit reader instance.
      *
-     * @var AuditReader<T>
+     * @var AuditReader
      */
     protected $auditReader;
 
@@ -105,7 +105,7 @@ class AuditedCollection implements Collection
      * @param array<string, mixed> $foreignKeys
      * @param string|int           $revision
      *
-     * @phpstan-param AuditReader<T> $auditReader
+     * @phpstan-param AuditReader $auditReader
      * @phpstan-param class-string<T> $class
      * @phpstan-param ClassMetadataInfo<T> $classMeta
      */

--- a/src/Collection/AuditedCollection.php
+++ b/src/Collection/AuditedCollection.php
@@ -53,7 +53,7 @@ class AuditedCollection implements Collection
     /**
      * Maximum revision to fetch.
      *
-     * @var string
+     * @var string|int
      */
     protected $revision;
 
@@ -74,7 +74,7 @@ class AuditedCollection implements Collection
      * initialized yet or contain identifiers to load the entities.
      *
      * @var Collection<int|string, array>
-     * @phpstan-var Collection<TKey, array{keys: array, rev: string|int}>
+     * @phpstan-var Collection<TKey, array{keys: array<string, int|string>, rev: string|int}>
      */
     protected $entities;
 
@@ -103,6 +103,7 @@ class AuditedCollection implements Collection
      * @param string               $class
      * @param array<string, mixed> $associationDefinition
      * @param array<string, mixed> $foreignKeys
+     * @param string|int           $revision
      *
      * @phpstan-param AuditReader<T> $auditReader
      * @phpstan-param class-string<T> $class

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -57,6 +57,9 @@ class SimpleThingsEntityAuditExtension extends Extension
         ]);
     }
 
+    /**
+     * @param string[] $definitionNames
+     */
     private function fixParametersFromDoctrineEventSubscriberTag(ContainerBuilder $container, array $definitionNames): void
     {
         foreach ($definitionNames as $definitionName) {

--- a/tests/Issue/Issue308Test.php
+++ b/tests/Issue/Issue308Test.php
@@ -44,7 +44,9 @@ final class Issue308Test extends BaseTest
         $revisions = $auditReader->findRevisions($userClass, $user->getId());
         static::assertCount(1, $revisions);
         $revision = reset($revisions);
-        $auditedUser = $auditReader->find($userClass, ['id' => $user->getId()], $revision->getRev());
+        $userId = $user->getId();
+        static::assertNotNull($userId);
+        $auditedUser = $auditReader->find($userClass, ['id' => $userId], $revision->getRev());
 
         static::assertInstanceOf(Collection::class, $auditedUser->getChildren());
     }

--- a/tests/RelationTest.php
+++ b/tests/RelationTest.php
@@ -790,8 +790,10 @@ final class RelationTest extends BaseTest
 
         $auditedBase = $reader->find(\get_class($base), $base->getId(), 1);
 
-        static::assertSame('foobar', $auditedBase->getReferencedEntity()->getFoobarField());
-        static::assertSame('referenced', $auditedBase->getReferencedEntity()->getReferencedField());
+        $referencedEntity = $auditedBase->getReferencedEntity();
+        static::assertInstanceOf(RelationFoobarEntity::class, $referencedEntity);
+        static::assertSame('foobar', $referencedEntity->getFoobarField());
+        static::assertSame('referenced', $referencedEntity->getReferencedField());
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Alternative to https://github.com/sonata-project/EntityAuditBundle/pull/487 making `AuditReader` not generic.

Raising PHPStan level after this to level 7 shows 23 errors.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Specify iterable types
### Changed
- Make `AuditReader` not generic
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
