### PR TITLE
Copy internal SQLResultCasing from ORM

### DIFF
--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\ORMException;
@@ -31,6 +30,7 @@ use SimpleThings\EntityAudit\Exception\NoRevisionFoundException;
 use SimpleThings\EntityAudit\Exception\NotAuditedException;
 use SimpleThings\EntityAudit\Metadata\MetadataFactory;
 use SimpleThings\EntityAudit\Utils\ArrayDiff;
+use SimpleThings\EntityAudit\Utils\SQLResultCasing;
 
 /**
  * @phpstan-template T of object

--- a/src/Utils/SQLResultCasing.php
+++ b/src/Utils/SQLResultCasing.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SimpleThings\EntityAudit\Utils;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+
+/**
+ * This trait is a copy of \Doctrine\ORM\Internal\SQLResultCasing.
+ *
+ * @see https://github.com/doctrine/orm/blob/8f7701279de84411020304f668cc8b49a5afbf5a/lib/Doctrine/ORM/Internal/SQLResultCasing.php
+ *
+ * @internal
+ */
+trait SQLResultCasing
+{
+    private function getSQLResultCasing(AbstractPlatform $platform, string $column): string
+    {
+        if ($platform instanceof DB2Platform || $platform instanceof OraclePlatform) {
+            return strtoupper($column);
+        }
+
+        if ($platform instanceof PostgreSQLPlatform) {
+            return strtolower($column);
+        }
+
+        if (method_exists($platform, 'getSQLResultCasing')) {
+            return $platform->getSQLResultCasing($column);
+        }
+
+        return $column;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When using the bundle along with symfony error handler the user gets a deprecation warning about using an internal trait:

```
The "Doctrine\ORM\Internal\SQLResultCasing" trait is considered internal. It may change without further notice. You should not use it from "SimpleThings\EntityAudit\AuditReader".
```

I've copied the trait to our domain.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecation warning about using `SQLResultCasing` internal trait
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
