### PR TITLE
Fix schema creation for self referencing many to many association

### DIFF
--- a/tests/Fixtures/Relation/BaseSelfReferencingManyToManyEntity.php
+++ b/tests/Fixtures/Relation/BaseSelfReferencingManyToManyEntity.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Relation;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="type", type="string")
+ * @ORM\DiscriminatorMap({
+ *     "type 1": "Sonata\EntityAuditBundle\Tests\Fixtures\Relation\SelfReferencingManyToManyEntity"
+ * })
+ */
+abstract class BaseSelfReferencingManyToManyEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string", name="title")
+     */
+    private string $title;
+
+    /**
+     * @var Collection<int, BaseSelfReferencingManyToManyEntity>
+     *
+     * @ORM\ManyToMany(targetEntity="BaseSelfReferencingManyToManyEntity")
+     * @ORM\JoinTable(
+     *     name="self_referencing_linked_table",
+     *     joinColumns={@ORM\JoinColumn(name="foo_id", referencedColumnName="id")},
+     *     inverseJoinColumns={@ORM\JoinColumn(name="bar_id", referencedColumnName="id")}
+     * )
+     */
+    private Collection $linkedEntities;
+
+    public function __construct(string $title)
+    {
+        $this->title = $title;
+        $this->linkedEntities = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function addLinkedEntity(self $selfReferencingManyToManyEntity): self
+    {
+        if (!$this->linkedEntities->contains($selfReferencingManyToManyEntity)) {
+            $this->linkedEntities->add($selfReferencingManyToManyEntity);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Relation/SelfReferencingManyToManyEntity.php
+++ b/tests/Fixtures/Relation/SelfReferencingManyToManyEntity.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Relation;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class SelfReferencingManyToManyEntity extends BaseSelfReferencingManyToManyEntity
+{
+}

--- a/tests/Issue/IssueSelfReferencingManyToManyEntityTest.php
+++ b/tests/Issue/IssueSelfReferencingManyToManyEntityTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Issue;
+
+use Sonata\EntityAuditBundle\Tests\BaseTest;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\BaseSelfReferencingManyToManyEntity;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\SelfReferencingManyToManyEntity;
+
+final class IssueSelfReferencingManyToManyEntityTest extends BaseTest
+{
+    protected $schemaEntities = [
+        BaseSelfReferencingManyToManyEntity::class,
+        SelfReferencingManyToManyEntity::class,
+    ];
+
+    protected $auditedEntities = [
+        SelfReferencingManyToManyEntity::class,
+    ];
+
+    public function testSelfReferencingManyToManyAssociationWithClassTableInheritanceWorks(): void
+    {
+        $entity = new SelfReferencingManyToManyEntity('foo');
+        $entityTwo = new SelfReferencingManyToManyEntity('xyz');
+        $entity->addLinkedEntity($entityTwo);
+
+        $this->em->persist($entity);
+        $this->em->persist($entityTwo);
+        $this->em->flush();
+
+        $entityId = $entity->getId();
+
+        \assert(\is_int($entityId));
+
+        $this->em->clear();
+
+        /** @var SelfReferencingManyToManyEntity $entity */
+        $entity = $this->em->getRepository(SelfReferencingManyToManyEntity::class)->find($entityId);
+
+        $entity->setTitle('bar');
+        $this->em->flush();
+
+        $reader = $this->auditManager->createAuditReader($this->em);
+
+        $auditEntity = $reader->find(SelfReferencingManyToManyEntity::class, $entityId, 1);
+        static::assertInstanceOf(SelfReferencingManyToManyEntity::class, $auditEntity);
+        static::assertSame('foo', $auditEntity->getTitle());
+
+        $auditEntity = $reader->find(SelfReferencingManyToManyEntity::class, $entityId, 2);
+        static::assertInstanceOf(SelfReferencingManyToManyEntity::class, $auditEntity);
+        static::assertSame('bar', $auditEntity->getTitle());
+
+        $this->em->clear();
+
+        /** @var SelfReferencingManyToManyEntity $entity */
+        $entity = $this->em->getRepository(SelfReferencingManyToManyEntity::class)->find($entityId);
+
+        $this->em->remove($entity);
+        $this->em->flush();
+
+        $auditEntity = $reader->find(SelfReferencingManyToManyEntity::class, $entityId, 3);
+        static::assertInstanceOf(SelfReferencingManyToManyEntity::class, $auditEntity);
+        static::assertSame('bar', $auditEntity->getTitle());
+    }
+}


### PR DESCRIPTION
## Subject

I am targeting this branch, because it's a bug fix.

We've tried to upgrade from 1.7 to 1.9 but our CI was failing with the following exception:

```
Doctrine\DBAL\Schema\Exception\TableDoesNotExist: There is no table with name "foo" in the schema.
/app/vendor/doctrine/dbal/src/Schema/Exception/TableDoesNotExist.php:16
/app/vendor/doctrine/dbal/src/Schema/SchemaException.php:68
/app/vendor/doctrine/dbal/src/Schema/Schema.php:188
/app/vendor/sonata-project/entity-audit-bundle/src/EventListener/CreateSchemaListener.php:102
```

Further debugging showed that the issue was introduced in https://github.com/sonata-project/EntityAuditBundle/pull/509 as the case of a self referencing many to many association which uses class table inheritance was not taken into consideration in the create schema listener class so it currently tries to create the revision/audit table for the related table which does not yet exist at that point. The fix was to execute that logic (if we run into that case) in the post schema generation event instead where we are sure that all schema tables are created so we can then safely create the revision table for them.

## Changelog

```markdown
### Fixed
- Schema creation for self referencing many to many association with class table inheritance
```