### PR TITLE
Fix not null constraint failed during many to many audit recording

### DIFF
--- a/src/DeferredChangedManyToManyEntityRevisionToPersist.php
+++ b/src/DeferredChangedManyToManyEntityRevisionToPersist.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SimpleThings\EntityAudit;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * @internal
+ */
+final class DeferredChangedManyToManyEntityRevisionToPersist
+{
+    private object $entity;
+    private string $revType;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $entityData;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $assoc;
+
+    /**
+     * @var ClassMetadata<object>
+     */
+    private ClassMetadata $class;
+
+    /**
+     * @var ClassMetadata<object>
+     */
+    private ClassMetadata $targetClass;
+
+    /**
+     * @param array<string, mixed>  $assoc
+     * @param array<string, mixed>  $entityData
+     * @param ClassMetadata<object> $class
+     * @param ClassMetadata<object> $targetClass
+     */
+    public function __construct(object $entity, string $revType, array $entityData, array $assoc, ClassMetadata $class, ClassMetadata $targetClass)
+    {
+        $this->entity = $entity;
+        $this->revType = $revType;
+        $this->entityData = $entityData;
+        $this->assoc = $assoc;
+        $this->class = $class;
+        $this->targetClass = $targetClass;
+    }
+
+    public function getEntity(): object
+    {
+        return $this->entity;
+    }
+
+    public function getRevType(): string
+    {
+        return $this->revType;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getEntityData(): array
+    {
+        return $this->entityData;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAssoc(): array
+    {
+        return $this->assoc;
+    }
+
+    /**
+     * @return ClassMetadata<object>
+     */
+    public function getClass(): ClassMetadata
+    {
+        return $this->class;
+    }
+
+    /**
+     * @return ClassMetadata<object>
+     */
+    public function getTargetClass(): ClassMetadata
+    {
+        return $this->targetClass;
+    }
+}

--- a/tests/Fixtures/Relation/UnidirectionalManyToManyEntity.php
+++ b/tests/Fixtures/Relation/UnidirectionalManyToManyEntity.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Relation;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class UnidirectionalManyToManyEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private string $title;
+
+    /**
+     * @var Collection<int, UnidirectionalManyToManyLinkedEntity>
+     *
+     * @ORM\ManyToMany(targetEntity="UnidirectionalManyToManyLinkedEntity")
+     * @ORM\JoinTable(name="unidirectional_many_to_many_linked_entity",
+     *   joinColumns={@ORM\JoinColumn(name="foo_id", referencedColumnName="id")},
+     *   inverseJoinColumns={@ORM\JoinColumn(name="bar_id", referencedColumnName="id")}
+     * )
+     */
+    private Collection $linkedEntity;
+
+    public function __construct(string $title)
+    {
+        $this->title = $title;
+        $this->linkedEntity = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return Collection<int, UnidirectionalManyToManyLinkedEntity>
+     */
+    public function getLinkedEntities(): Collection
+    {
+        return $this->linkedEntity;
+    }
+
+    public function addLinkedEntity(UnidirectionalManyToManyLinkedEntity $linkedEntity): void
+    {
+        if (false === $this->linkedEntity->contains($linkedEntity)) {
+            $this->linkedEntity->add($linkedEntity);
+        }
+    }
+}

--- a/tests/Fixtures/Relation/UnidirectionalManyToManyLinkedEntity.php
+++ b/tests/Fixtures/Relation/UnidirectionalManyToManyLinkedEntity.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Relation;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class UnidirectionalManyToManyLinkedEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Issue/IssueUnidirectionalManyToManyEntityTest.php
+++ b/tests/Issue/IssueUnidirectionalManyToManyEntityTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Issue;
+
+use Sonata\EntityAuditBundle\Tests\BaseTest;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\UnidirectionalManyToManyEntity;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\UnidirectionalManyToManyLinkedEntity;
+
+final class IssueUnidirectionalManyToManyEntityTest extends BaseTest
+{
+    protected $schemaEntities = [
+        UnidirectionalManyToManyEntity::class,
+        UnidirectionalManyToManyLinkedEntity::class,
+    ];
+
+    protected $auditedEntities = [
+        UnidirectionalManyToManyEntity::class,
+        UnidirectionalManyToManyLinkedEntity::class,
+    ];
+
+    public function testUnidirectionalManyToManyAssociationWorksWhenTheMainEntityIsTheOneBeingPersistedFirst(): void
+    {
+        $entity = new UnidirectionalManyToManyEntity('foo');
+        $entityTwo = new UnidirectionalManyToManyLinkedEntity('xyz');
+        $entity->addLinkedEntity($entityTwo);
+
+        $this->em->persist($entity);
+        $this->em->persist($entityTwo);
+        $this->em->flush();
+
+        $entityOneId = $entity->getId();
+        $entityTwoId = $entityTwo->getId();
+
+        \assert(\is_int($entityOneId));
+        \assert(\is_int($entityTwoId));
+
+        $this->assertAuditRecordsWereCorrectlyRecorded($entityOneId, $entityTwoId);
+    }
+
+    public function testUnidirectionalManyToManyAssociationWorksWhenTheLinkedEntityIsTheOneBeingPersistedFirst(): void
+    {
+        $entity = new UnidirectionalManyToManyEntity('foo');
+        $entityTwo = new UnidirectionalManyToManyLinkedEntity('xyz');
+        $entity->addLinkedEntity($entityTwo);
+
+        $this->em->persist($entityTwo);
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $entityOneId = $entity->getId();
+        $entityTwoId = $entityTwo->getId();
+
+        \assert(\is_int($entityOneId));
+        \assert(\is_int($entityTwoId));
+
+        $this->assertAuditRecordsWereCorrectlyRecorded($entityOneId, $entityTwoId);
+    }
+
+    private function assertAuditRecordsWereCorrectlyRecorded(int $mainEntityId, int $linkedEntityId): void
+    {
+        $this->em->clear();
+
+        /** @var UnidirectionalManyToManyEntity $entity */
+        $entity = $this->em->getRepository(UnidirectionalManyToManyEntity::class)->find($mainEntityId);
+        /** @var UnidirectionalManyToManyLinkedEntity $entityTwo */
+        $entityTwo = $this->em->getRepository(UnidirectionalManyToManyLinkedEntity::class)->find($linkedEntityId);
+
+        $entity->setTitle('bar');
+        $entityTwo->setName('zxy');
+        $this->em->flush();
+
+        $reader = $this->auditManager->createAuditReader($this->em);
+
+        $auditEntity = $reader->find(UnidirectionalManyToManyEntity::class, $mainEntityId, 1);
+        static::assertInstanceOf(UnidirectionalManyToManyEntity::class, $auditEntity);
+        static::assertSame('foo', $auditEntity->getTitle());
+        static::assertCount(1, $auditEntity->getLinkedEntities());
+        static::assertInstanceOf(UnidirectionalManyToManyLinkedEntity::class, $auditEntity->getLinkedEntities()[0]);
+        static::assertSame('xyz', $auditEntity->getLinkedEntities()[0]->getName());
+
+        $auditEntity = $reader->find(UnidirectionalManyToManyEntity::class, $mainEntityId, 2);
+        static::assertInstanceOf(UnidirectionalManyToManyEntity::class, $auditEntity);
+        static::assertSame('bar', $auditEntity->getTitle());
+        static::assertCount(1, $auditEntity->getLinkedEntities());
+        static::assertInstanceOf(UnidirectionalManyToManyLinkedEntity::class, $auditEntity->getLinkedEntities()[0]);
+        static::assertSame('zxy', $auditEntity->getLinkedEntities()[0]->getName());
+
+        $this->em->clear();
+
+        /** @var UnidirectionalManyToManyEntity $entity */
+        $entity = $this->em->getRepository(UnidirectionalManyToManyEntity::class)->find($mainEntityId);
+
+        $this->em->remove($entity);
+        $this->em->flush();
+
+        $auditEntity = $reader->find(UnidirectionalManyToManyEntity::class, $mainEntityId, 3);
+        static::assertInstanceOf(UnidirectionalManyToManyEntity::class, $auditEntity);
+        static::assertSame('bar', $auditEntity->getTitle());
+        static::assertCount(1, $auditEntity->getLinkedEntities());
+        static::assertInstanceOf(UnidirectionalManyToManyLinkedEntity::class, $auditEntity->getLinkedEntities()[0]);
+        static::assertSame('zxy', $auditEntity->getLinkedEntities()[0]->getName());
+    }
+}


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a bug fix.

The computed commit order in the unit of work is different depending on the order in which `$entityManager->persist()` calls were made. The audit logic for inserting `INS` revision type records is executed on the `postPersist` event (which is dispatched in the commit order). That means that we have two possible cases here depending on the order of  `$entityManager->persist()` calls:

```php
$em->persist($entityOne);
$em->persist($entityTwo);
$em->flush();
```

A persisted first, B persisted second -> by the time the `postPersist` event logic is executed for A entity the B entity was already flushed to the database so it's got the ID and everything works fine

```php
$em->persist($entityTwo);
$em->persist($entityOne);
$em->flush();
```

B persisted first, A persisted second -> by the time the `postPersist` event logic is executed for A entity the B entity has NOT been flushed to the database yet so its ID field was still null and as there was no code in place to handle this scenario we'd get a `Doctrine\DBAL\Exception\NotNullConstraintViolationException: An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 19 NOT NULL constraint failed` exception

This PR fixes this issue by deferring the save of the revision record for that case to the `postFlush` event by which point we are sure that all changes in the entity manager were flushed to the database (which means that our entity now has its ID assigned).

I've added tests to ensure that both cases work with this fix.

Closes #522.

## Changelog
```markdown
### Fixed
- Not null constraint violation during many to many association audit recording
```