### PR TITLE
Allow Doctrine Event manager v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/collections": "^1.6",
         "doctrine/common": "^3.1",
         "doctrine/dbal": "^2.13 || ^3.0",
-        "doctrine/event-manager": "^1.1",
+        "doctrine/event-manager": "^1.2 || ^2.0",
         "doctrine/orm": "^2.10",
         "doctrine/persistence": "^2.2 || ^3.0",
         "psr/clock": "^1.0",

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -114,7 +114,7 @@ abstract class BaseTest extends TestCase
 
         // get rid of more global state
         $evm = $connection->getEventManager();
-        foreach ($evm->getListeners() as $event => $listeners) {
+        foreach ($evm->getAllListeners() as $event => $listeners) {
             foreach ($listeners as $listener) {
                 $evm->removeEventListener([$event], $listener);
             }


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a backwards compatible change.

## Changelog

```markdown
### Added
- Support for Doctrine Event manager v2
```