### PR TITLE
Clear extra updates array to prevent memory leak

### DIFF
--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -86,7 +86,7 @@ class LogRevisionsListener implements EventSubscriber
      */
     public function getSubscribedEvents()
     {
-        return [Events::onFlush, Events::postPersist, Events::postUpdate, Events::postFlush];
+        return [Events::onFlush, Events::postPersist, Events::postUpdate, Events::postFlush, Events::onClear];
     }
 
     /**
@@ -252,6 +252,11 @@ class LogRevisionsListener implements EventSubscriber
         );
 
         $this->saveRevisionEntityData($em, $class, $entityData, 'UPD');
+    }
+
+    public function onClear(): void
+    {
+        $this->extraUpdates = [];
     }
 
     public function onFlush(OnFlushEventArgs $eventArgs): void


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a bug fix.
The `extraUpdates` array property is never being cleared so this results in memory leaks in long running processes (like Symfony Messenger queues) - now it's gonna be cleared on every `$entityManager->clear()` call.

## Changelog

```markdown
### Fixed
- Clear extra updates array to prevent memory leak
```