### PR TITLE
Clear entity cache to prevent memory leak

### DIFF
--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -54,6 +54,7 @@ class SimpleThingsEntityAuditExtension extends Extension
         $this->fixParametersFromDoctrineEventSubscriberTag($container, [
             'simplethings_entityaudit.log_revisions_listener',
             'simplethings_entityaudit.create_schema_listener',
+            'simplethings_entityaudit.cache_listener',
         ]);
     }
 

--- a/src/EventListener/CacheListener.php
+++ b/src/EventListener/CacheListener.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SimpleThings\EntityAudit\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Events;
+use SimpleThings\EntityAudit\AuditReader;
+
+final class CacheListener implements EventSubscriber
+{
+    private AuditReader $auditReader;
+
+    public function __construct(AuditReader $auditReader)
+    {
+        $this->auditReader = $auditReader;
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [Events::onClear];
+    }
+
+    public function onClear(): void
+    {
+        $this->auditReader->clearEntityCache();
+    }
+}

--- a/src/Resources/config/auditable.php
+++ b/src/Resources/config/auditable.php
@@ -18,6 +18,7 @@ use Psr\Clock\ClockInterface;
 use SimpleThings\EntityAudit\AuditConfiguration;
 use SimpleThings\EntityAudit\AuditManager;
 use SimpleThings\EntityAudit\AuditReader;
+use SimpleThings\EntityAudit\EventListener\CacheListener;
 use SimpleThings\EntityAudit\EventListener\CreateSchemaListener;
 use SimpleThings\EntityAudit\EventListener\LogRevisionsListener;
 use SimpleThings\EntityAudit\User\TokenStorageUsernameCallable;
@@ -68,6 +69,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('simplethings_entityaudit.create_schema_listener', CreateSchemaListener::class)
             ->tag('doctrine.event_subscriber', ['connection' => '%simplethings.entityaudit.connection%'])
             ->args([new ReferenceConfigurator('simplethings_entityaudit.manager')])
+
+        ->set('simplethings_entityaudit.cache_listener', CacheListener::class)
+            ->tag('doctrine.event_subscriber', ['connection' => '%simplethings.entityaudit.connection%'])
+            ->args([new ReferenceConfigurator('simplethings_entityaudit.reader')])
 
         ->set('simplethings_entityaudit.username_callable.token_storage', TokenStorageUsernameCallable::class)
             ->args([new ReferenceConfigurator('security.token_storage')])


### PR DESCRIPTION
## Subject
I am targeting this branch, because this is a bug fix. The issue and the fix is the same as in https://github.com/sonata-project/EntityAuditBundle/pull/543.

## Changelog

```markdown
### Fixed
- Clear entity cache to prevent memory leak
```