### PR TITLE
Drop restriction for doctrine/annotations, up doctrine bundle min version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "twig/twig": "^2.6 || ^3.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^2.4.4",
+        "doctrine/doctrine-bundle": "^2.7",
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "friendsofphp/php-cs-fixer": "^3.4",
         "gedmo/doctrine-extensions": "^3.7",
@@ -51,8 +51,7 @@
         "weirdan/doctrine-psalm-plugin": "^2.8"
     },
     "conflict": {
-        "doctrine/annotations": "<1.7",
-        "doctrine/doctrine-bundle": "<2.4.4",
+        "doctrine/doctrine-bundle": "<2.7",
         "gedmo/doctrine-extensions": "<3.7",
         "symfony/framework-bundle": "<4.4"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for `doctrine/doctrine-bundle` < 2.7.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
