### PR TITLE
Allow sql keywords as column name

### DIFF
--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -424,7 +424,7 @@ class LogRevisionsListener implements EventSubscriber
                 $placeholders[] = true === ($class->fieldMappings[$field]['requireSQLConversion'] ?? false)
                     ? $type->convertToDatabaseValueSQL('?', $platform)
                     : '?';
-                $sql .= ', `'.$em->getConfiguration()->getQuoteStrategy()->getColumnName($field, $class, $platform).'`';
+                $sql .= ', '.$em->getConfiguration()->getQuoteStrategy()->getColumnName($field, $class, $platform);
             }
 
             if (

--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -384,8 +384,8 @@ class LogRevisionsListener implements EventSubscriber
             $placeholders = ['?', '?'];
             $tableName = $this->config->getTableName($class);
 
-            $sql = 'INSERT INTO '.$tableName.' ('.
-                $this->config->getRevisionFieldName().', '.$this->config->getRevisionTypeFieldName();
+            $sql = 'INSERT INTO '.$tableName.' (`'.
+                $this->config->getRevisionFieldName().'`, `'.$this->config->getRevisionTypeFieldName() . '`';
 
             $fields = [];
 
@@ -401,7 +401,7 @@ class LogRevisionsListener implements EventSubscriber
                 ) {
                     foreach ($assoc['targetToSourceKeyColumns'] as $sourceCol) {
                         $fields[$sourceCol] = true;
-                        $sql .= ', '.$sourceCol;
+                        $sql .= ', `'.$sourceCol . '`';
                         $placeholders[] = '?';
                     }
                 }
@@ -424,7 +424,7 @@ class LogRevisionsListener implements EventSubscriber
                 $placeholders[] = true === ($class->fieldMappings[$field]['requireSQLConversion'] ?? false)
                     ? $type->convertToDatabaseValueSQL('?', $platform)
                     : '?';
-                $sql .= ', '.$em->getConfiguration()->getQuoteStrategy()->getColumnName($field, $class, $platform);
+                $sql .= ', `'.$em->getConfiguration()->getQuoteStrategy()->getColumnName($field, $class, $platform) . '`';
             }
 
             if (
@@ -434,7 +434,7 @@ class LogRevisionsListener implements EventSubscriber
                 )
                 && null !== $class->discriminatorColumn
             ) {
-                $sql .= ', '.$class->discriminatorColumn['name'];
+                $sql .= ', `'.$class->discriminatorColumn['name'] . '`';
                 $placeholders[] = '?';
             }
 

--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -385,7 +385,7 @@ class LogRevisionsListener implements EventSubscriber
             $tableName = $this->config->getTableName($class);
 
             $sql = 'INSERT INTO '.$tableName.' (`'.
-                $this->config->getRevisionFieldName().'`, `'.$this->config->getRevisionTypeFieldName() . '`';
+                $this->config->getRevisionFieldName().'`, `'.$this->config->getRevisionTypeFieldName().'`';
 
             $fields = [];
 
@@ -401,7 +401,7 @@ class LogRevisionsListener implements EventSubscriber
                 ) {
                     foreach ($assoc['targetToSourceKeyColumns'] as $sourceCol) {
                         $fields[$sourceCol] = true;
-                        $sql .= ', `'.$sourceCol . '`';
+                        $sql .= ', `'.$sourceCol.'`';
                         $placeholders[] = '?';
                     }
                 }
@@ -424,7 +424,7 @@ class LogRevisionsListener implements EventSubscriber
                 $placeholders[] = true === ($class->fieldMappings[$field]['requireSQLConversion'] ?? false)
                     ? $type->convertToDatabaseValueSQL('?', $platform)
                     : '?';
-                $sql .= ', `'.$em->getConfiguration()->getQuoteStrategy()->getColumnName($field, $class, $platform) . '`';
+                $sql .= ', `'.$em->getConfiguration()->getQuoteStrategy()->getColumnName($field, $class, $platform).'`';
             }
 
             if (
@@ -434,7 +434,7 @@ class LogRevisionsListener implements EventSubscriber
                 )
                 && null !== $class->discriminatorColumn
             ) {
-                $sql .= ', `'.$class->discriminatorColumn['name'] . '`';
+                $sql .= ', `'.$class->discriminatorColumn['name'].'`';
                 $placeholders[] = '?';
             }
 


### PR DESCRIPTION
I don't know wether this is a proper PR, but unfortunately I'm overworked but I think this is so important to fix, that maybe someone will fix anything which needs to be done before merging it.

Currently when having a column name like `order` it breaks the audit insert and throws an exception:

    An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'order) VALUES (41, 'UPD', '?mjr?L?EBU?m?', '???0,?GI??#?G?', 'Gsadf at line 14

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the problem for me lives in 1.12.0.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Security
- Allow SQL keywords in column names by properly escaping them

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
