### PR TITLE
use event_listener instead of event_subscriber

### DIFF
--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -65,8 +65,8 @@ class SimpleThingsEntityAuditExtension extends Extension
     {
         foreach ($definitionNames as $definitionName) {
             $definition = $container->getDefinition($definitionName);
-            $tags = $definition->getTag('doctrine.event_subscriber');
-            $definition->clearTag('doctrine.event_subscriber');
+            $tags = $definition->getTag('doctrine.event_listener');
+            $definition->clearTag('doctrine.event_listener');
 
             foreach ($tags as $attributes) {
                 if (isset($attributes['connection'])) {
@@ -75,7 +75,7 @@ class SimpleThingsEntityAuditExtension extends Extension
 
                     $attributes['connection'] = (string) $connection;
                 }
-                $definition->addTag('doctrine.event_subscriber', $attributes);
+                $definition->addTag('doctrine.event_listener', $attributes);
             }
         }
     }

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -51,7 +51,7 @@ class SimpleThingsEntityAuditExtension extends Extension
             }
         }
 
-        $this->fixParametersFromDoctrineEventSubscriberTag($container, [
+        $this->fixParametersFromDoctrineEventListenerTag($container, [
             'simplethings_entityaudit.log_revisions_listener',
             'simplethings_entityaudit.create_schema_listener',
             'simplethings_entityaudit.cache_listener',
@@ -61,7 +61,7 @@ class SimpleThingsEntityAuditExtension extends Extension
     /**
      * @param string[] $definitionNames
      */
-    private function fixParametersFromDoctrineEventSubscriberTag(ContainerBuilder $container, array $definitionNames): void
+    private function fixParametersFromDoctrineEventListenerTag(ContainerBuilder $container, array $definitionNames): void
     {
         foreach ($definitionNames as $definitionName) {
             $definition = $container->getDefinition($definitionName);

--- a/src/EventListener/CacheListener.php
+++ b/src/EventListener/CacheListener.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Events;
 use SimpleThings\EntityAudit\AuditReader;
 
 /**
- * NEXT_MAJOR: do not implement EventSubscriber interface anymore
+ * NEXT_MAJOR: do not implement EventSubscriber interface anymore.
  */
 final class CacheListener implements EventSubscriber
 {

--- a/src/EventListener/CacheListener.php
+++ b/src/EventListener/CacheListener.php
@@ -17,12 +17,18 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Events;
 use SimpleThings\EntityAudit\AuditReader;
 
+/**
+ * NEXT_MAJOR: do not implement EventSubscriber interface anymore
+ */
 final class CacheListener implements EventSubscriber
 {
     public function __construct(private AuditReader $auditReader)
     {
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     public function getSubscribedEvents(): array
     {
         return [Events::onClear];

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -27,6 +27,9 @@ use SimpleThings\EntityAudit\AuditConfiguration;
 use SimpleThings\EntityAudit\AuditManager;
 use SimpleThings\EntityAudit\Metadata\MetadataFactory;
 
+/**
+ * NEXT_MAJOR: do not implement EventSubscriber interface anymore
+ */
 class CreateSchemaListener implements EventSubscriber
 {
     private AuditConfiguration $config;
@@ -46,6 +49,7 @@ class CreateSchemaListener implements EventSubscriber
 
     /**
      * @return string[]
+     * NEXT_MAJOR: remove this method.
      */
     #[\ReturnTypeWillChange]
     public function getSubscribedEvents()

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -28,7 +28,7 @@ use SimpleThings\EntityAudit\AuditManager;
 use SimpleThings\EntityAudit\Metadata\MetadataFactory;
 
 /**
- * NEXT_MAJOR: do not implement EventSubscriber interface anymore
+ * NEXT_MAJOR: do not implement EventSubscriber interface anymore.
  */
 class CreateSchemaListener implements EventSubscriber
 {

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -48,8 +48,9 @@ class CreateSchemaListener implements EventSubscriber
     }
 
     /**
-     * @return string[]
      * NEXT_MAJOR: remove this method.
+     *
+     * @return string[]
      */
     #[\ReturnTypeWillChange]
     public function getSubscribedEvents()

--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -81,8 +81,9 @@ class LogRevisionsListener implements EventSubscriber
     }
 
     /**
-     * @return string[]
      * NEXT_MAJOR: remove this method.
+     *
+     * @return string[]
      */
     #[\ReturnTypeWillChange]
     public function getSubscribedEvents()

--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -36,7 +36,7 @@ use SimpleThings\EntityAudit\DeferredChangedManyToManyEntityRevisionToPersist;
 use SimpleThings\EntityAudit\Metadata\MetadataFactory;
 
 /**
- * NEXT_MAJOR: do not implement EventSubscriber interface anymore
+ * NEXT_MAJOR: do not implement EventSubscriber interface anymore.
  */
 class LogRevisionsListener implements EventSubscriber
 {

--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -35,6 +35,9 @@ use SimpleThings\EntityAudit\AuditManager;
 use SimpleThings\EntityAudit\DeferredChangedManyToManyEntityRevisionToPersist;
 use SimpleThings\EntityAudit\Metadata\MetadataFactory;
 
+/**
+ * NEXT_MAJOR: do not implement EventSubscriber interface anymore
+ */
 class LogRevisionsListener implements EventSubscriber
 {
     private AuditConfiguration $config;
@@ -79,6 +82,7 @@ class LogRevisionsListener implements EventSubscriber
 
     /**
      * @return string[]
+     * NEXT_MAJOR: remove this method.
      */
     #[\ReturnTypeWillChange]
     public function getSubscribedEvents()

--- a/src/Resources/config/auditable.php
+++ b/src/Resources/config/auditable.php
@@ -108,7 +108,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('simplethings_entityaudit.cache_listener', CacheListener::class)
             ->tag('doctrine.event_listener', [
-                'event' => Events::prePersist,
+                'event' => Events::onClear,
                 'connection' => (string) param('simplethings.entityaudit.connection'),
             ])
             ->args([service('simplethings_entityaudit.reader')])


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it should be BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Deprecation of Event Subscribers on Symfony 6.3. They now uses Event Listeners
```