### PR TITLE
Added the with_foreign_keys parameter to allow disabling the creation of foreign keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ simple_things_entity_audit:
     entity_manager: custom
 ```
 
-If there is no need to create foreign keys for any reason, you can specify the corresponding parameter:
+If you need to explicitly discard the foreign keys inferred from the audited entities, you can use the `disable_foreign_keys` parameter:
 ```yaml
 simple_things_entity_audit:
     disable_foreign_keys: true

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ simple_things_entity_audit:
     entity_manager: custom
 ```
 
+If there is no need to create foreign keys for any reason, you can specify the corresponding parameter:
+```yaml
+simple_things_entity_audit:
+    with_foreign_keys: false
+```
+
 ### Creating new tables
 
 Call the command below to see the new tables in the update schema queue.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ simple_things_entity_audit:
 If there is no need to create foreign keys for any reason, you can specify the corresponding parameter:
 ```yaml
 simple_things_entity_audit:
-    with_foreign_keys: false
+    disable_foreign_keys: true
 ```
 
 ### Creating new tables

--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -26,7 +26,7 @@ class AuditConfiguration
      */
     private array $auditedEntityClasses = [];
 
-    private bool $withForeignKeys = true;
+    private bool $disableForeignKeys = false;
 
     /**
      * @var string[]
@@ -81,14 +81,14 @@ class AuditConfiguration
         return $this->getTablePrefix().$tableName.$this->getTableSuffix();
     }
 
-    public function getWithForeignKeys(): bool
+    public function isDisabledForeignKeys(): bool
     {
-        return $this->withForeignKeys;
+        return $this->disableForeignKeys;
     }
 
-    public function setWithForeignKeys(bool $withForeignKeys): void
+    public function setDisabledForeignKeys(bool $disabled): void
     {
-        $this->withForeignKeys = $withForeignKeys;
+        $this->disableForeignKeys = $disabled;
     }
 
     /**

--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -81,7 +81,7 @@ class AuditConfiguration
         return $this->getTablePrefix().$tableName.$this->getTableSuffix();
     }
 
-    public function isDisabledForeignKeys(): bool
+    public function areForeignKeysDisabled(): bool
     {
         return $this->disableForeignKeys;
     }

--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -26,6 +26,8 @@ class AuditConfiguration
      */
     private array $auditedEntityClasses = [];
 
+    private bool $withForeignKeys = true;
+
     /**
      * @var string[]
      */
@@ -77,6 +79,16 @@ class AuditConfiguration
         }
 
         return $this->getTablePrefix().$tableName.$this->getTableSuffix();
+    }
+
+    public function getWithForeignKeys(): bool
+    {
+        return $this->withForeignKeys;
+    }
+
+    public function setWithForeignKeys(bool $withForeignKeys): void
+    {
+        $this->withForeignKeys = $withForeignKeys;
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -54,6 +54,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('revision_field_name')->defaultValue('rev')->end()
                 ->scalarNode('revision_type_field_name')->defaultValue('revtype')->end()
                 ->scalarNode('revision_table_name')->defaultValue('revisions')->end()
+                ->scalarNode('with_foreign_keys')->defaultValue('default')->end()
                 ->scalarNode('revision_id_field_type')
                     ->defaultValue(Types::INTEGER)
                     // NEXT_MAJOR: Use enumNode() instead.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -54,7 +54,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('revision_field_name')->defaultValue('rev')->end()
                 ->scalarNode('revision_type_field_name')->defaultValue('revtype')->end()
                 ->scalarNode('revision_table_name')->defaultValue('revisions')->end()
-                ->scalarNode('with_foreign_keys')->defaultValue('default')->end()
+                ->scalarNode('with_foreign_keys')->defaultValue(true)->end()
                 ->scalarNode('revision_id_field_type')
                     ->defaultValue(Types::INTEGER)
                     // NEXT_MAJOR: Use enumNode() instead.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -54,7 +54,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('revision_field_name')->defaultValue('rev')->end()
                 ->scalarNode('revision_type_field_name')->defaultValue('revtype')->end()
                 ->scalarNode('revision_table_name')->defaultValue('revisions')->end()
-                ->scalarNode('with_foreign_keys')->defaultValue(true)->end()
+                ->scalarNode('disable_foreign_keys')->defaultValue(false)->end()
                 ->scalarNode('revision_id_field_type')
                     ->defaultValue(Types::INTEGER)
                     // NEXT_MAJOR: Use enumNode() instead.

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -39,6 +39,7 @@ class SimpleThingsEntityAuditExtension extends Extension
             'revision_table_name',
             'revision_id_field_type',
             'global_ignore_columns',
+            'with_foreign_keys',
         ];
 
         foreach ($configurables as $key) {

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -39,7 +39,7 @@ class SimpleThingsEntityAuditExtension extends Extension
             'revision_table_name',
             'revision_id_field_type',
             'global_ignore_columns',
-            'with_foreign_keys',
+            'disable_foreign_keys',
         ];
 
         foreach ($configurables as $key) {

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -119,17 +119,9 @@ class CreateSchemaListener implements EventSubscriber
             }
         }
 
-        $revisionForeignKeyName = $this->config->getRevisionFieldName().'_'.md5($revisionTable->getName()).'_fk';
-        $primaryKey = $revisionsTable->getPrimaryKey();
-        \assert(null !== $primaryKey);
-
-        $revisionTable->addForeignKeyConstraint(
-            $revisionsTable,
-            [$this->config->getRevisionFieldName()],
-            $primaryKey->getColumns(),
-            [],
-            $revisionForeignKeyName
-        );
+        if ($this->config->getWithForeignKeys()) {
+            $this->createForeignKeys($revisionTable, $revisionsTable);
+        }
     }
 
     public function postGenerateSchema(GenerateSchemaEventArgs $eventArgs): void
@@ -140,6 +132,21 @@ class CreateSchemaListener implements EventSubscriber
         foreach ($this->defferedJoinTablesToCreate as $defferedJoinTableToCreate) {
             $this->createRevisionJoinTableForJoinTable($schema, $defferedJoinTableToCreate);
         }
+    }
+
+    private function createForeignKeys(Table $relatedTable, Table $revisionsTable): void
+    {
+        $revisionForeignKeyName = $this->config->getRevisionFieldName().'_'.md5($relatedTable->getName()).'_fk';
+        $primaryKey = $revisionsTable->getPrimaryKey();
+        \assert(null !== $primaryKey);
+
+        $relatedTable->addForeignKeyConstraint(
+            $revisionsTable,
+            [$this->config->getRevisionFieldName()],
+            $primaryKey->getColumns(),
+            [],
+            $revisionForeignKeyName
+        );
     }
 
     /**

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -119,7 +119,7 @@ class CreateSchemaListener implements EventSubscriber
             }
         }
 
-        if (!$this->config->isDisabledForeignKeys()) {
+        if (!$this->config->areForeignKeysDisabled()) {
             $this->createForeignKeys($revisionTable, $revisionsTable);
         }
     }

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -119,7 +119,7 @@ class CreateSchemaListener implements EventSubscriber
             }
         }
 
-        if ($this->config->getWithForeignKeys()) {
+        if (!$this->config->isDisabledForeignKeys()) {
             $this->createForeignKeys($revisionTable, $revisionsTable);
         }
     }

--- a/src/Resources/config/auditable.php
+++ b/src/Resources/config/auditable.php
@@ -47,7 +47,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('simplethings.entityaudit.revision_table_name', null)
 
-        ->set('simplethings.entityaudit.revision_id_field_type', null);
+        ->set('simplethings.entityaudit.revision_id_field_type', null)
+
+        ->set('simplethings.entityaudit.with_foreign_keys', null);
 
     $containerConfigurator->services()
         ->set('simplethings_entityaudit.manager', AuditManager::class)
@@ -119,6 +121,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('simplethings_entityaudit.config', AuditConfiguration::class)
             ->public()
             ->call('setAuditedEntityClasses', [param('simplethings.entityaudit.audited_entities')])
+            ->call('setWithForeignKeys', [param('simplethings.entityaudit.with_foreign_keys')])
             ->call('setGlobalIgnoreColumns', [param('simplethings.entityaudit.global_ignore_columns')])
             ->call('setTablePrefix', [param('simplethings.entityaudit.table_prefix')])
             ->call('setTableSuffix', [param('simplethings.entityaudit.table_suffix')])

--- a/src/Resources/config/auditable.php
+++ b/src/Resources/config/auditable.php
@@ -49,7 +49,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('simplethings.entityaudit.revision_id_field_type', null)
 
-        ->set('simplethings.entityaudit.with_foreign_keys', null);
+        ->set('simplethings.entityaudit.disable_foreign_keys', null);
 
     $containerConfigurator->services()
         ->set('simplethings_entityaudit.manager', AuditManager::class)
@@ -121,7 +121,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('simplethings_entityaudit.config', AuditConfiguration::class)
             ->public()
             ->call('setAuditedEntityClasses', [param('simplethings.entityaudit.audited_entities')])
-            ->call('setWithForeignKeys', [param('simplethings.entityaudit.with_foreign_keys')])
+            ->call('setDisabledForeignKeys', [param('simplethings.entityaudit.disable_foreign_keys')])
             ->call('setGlobalIgnoreColumns', [param('simplethings.entityaudit.global_ignore_columns')])
             ->call('setTablePrefix', [param('simplethings.entityaudit.table_prefix')])
             ->call('setTableSuffix', [param('simplethings.entityaudit.table_suffix')])

--- a/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -61,6 +61,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionIdFieldType', ['%simplethings.entityaudit.revision_id_field_type%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionFieldName', ['%simplethings.entityaudit.revision_field_name%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionTypeFieldName', ['%simplethings.entityaudit.revision_type_field_name%']);
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setWithForeignKeys', ['%simplethings.entityaudit.with_foreign_keys%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setUsernameCallable', ['simplethings_entityaudit.username_callable']);
     }
 
@@ -102,6 +103,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_field_name', 'rev');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_type_field_name', 'revtype');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_id_field_type', Types::INTEGER);
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.with_foreign_keys', true);
     }
 
     public function testItSetsConfiguredParameters(): void
@@ -117,6 +119,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
             'revision_id_field_type' => Types::GUID,
             'revision_field_name' => 'revision',
             'revision_type_field_name' => 'action',
+            'with_foreign_keys' => true,
         ]);
 
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.connection', 'my_custom_connection');
@@ -129,6 +132,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_id_field_type', Types::GUID);
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_field_name', 'revision');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_type_field_name', 'action');
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.with_foreign_keys', true);
 
         foreach ([Events::onFlush, Events::postPersist, Events::postUpdate, Events::postFlush, Events::onClear] as $event) {
             $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_listener', ['event' => $event, 'connection' => 'my_custom_connection']);

--- a/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -61,7 +61,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionIdFieldType', ['%simplethings.entityaudit.revision_id_field_type%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionFieldName', ['%simplethings.entityaudit.revision_field_name%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionTypeFieldName', ['%simplethings.entityaudit.revision_type_field_name%']);
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setWithForeignKeys', ['%simplethings.entityaudit.with_foreign_keys%']);
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setDisabledForeignKeys', ['%simplethings.entityaudit.disable_foreign_keys%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setUsernameCallable', ['simplethings_entityaudit.username_callable']);
     }
 
@@ -103,7 +103,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_field_name', 'rev');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_type_field_name', 'revtype');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_id_field_type', Types::INTEGER);
-        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.with_foreign_keys', true);
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.disable_foreign_keys', false);
     }
 
     public function testItSetsConfiguredParameters(): void
@@ -119,7 +119,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
             'revision_id_field_type' => Types::GUID,
             'revision_field_name' => 'revision',
             'revision_type_field_name' => 'action',
-            'with_foreign_keys' => true,
+            'disable_foreign_keys' => false,
         ]);
 
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.connection', 'my_custom_connection');
@@ -132,7 +132,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_id_field_type', Types::GUID);
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_field_name', 'revision');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_type_field_name', 'action');
-        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.with_foreign_keys', true);
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.disable_foreign_keys', false);
 
         foreach ([Events::onFlush, Events::postPersist, Events::postUpdate, Events::postFlush, Events::onClear] as $event) {
             $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_listener', ['event' => $event, 'connection' => 'my_custom_connection']);

--- a/tests/NoForeignKeysTest.php
+++ b/tests/NoForeignKeysTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests;
+
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use SimpleThings\EntityAudit\AuditConfiguration;
+use SimpleThings\EntityAudit\AuditManager;
+use SimpleThings\EntityAudit\Exception\NotAuditedException;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Core\UserAudit;
+
+final class NoForeignKeysTest extends BaseTest
+{
+    protected $schemaEntities = [
+        UserAudit::class,
+    ];
+
+    protected $auditedEntities = [
+        UserAudit::class,
+    ];
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     * @throws NotAuditedException
+     * @throws Exception
+     */
+    public function testRevisionForeignKeys(): void
+    {
+        $em = $this->getEntityManager();
+
+        $user = new UserAudit('phansys');
+
+        $em->persist($user);
+        $em->flush();
+
+        $reader = $this->getAuditManager()->createAuditReader($em);
+
+        $userId = $user->getId();
+        static::assertNotNull($userId);
+
+        $revisions = $reader->findRevisions(UserAudit::class, $userId);
+
+        static::assertCount(1, $revisions);
+
+        $revision = $reader->getCurrentRevision(UserAudit::class, $userId);
+        static::assertSame('1', (string) $revision);
+
+        $revisionsTableName = $this->getAuditManager()->getConfiguration()->getRevisionTableName();
+
+        $em->getConnection()->delete($revisionsTableName, ['id' => $revision]);
+    }
+
+    protected function getAuditManager(): AuditManager
+    {
+        if (null !== $this->auditManager) {
+            return $this->auditManager;
+        }
+
+        $auditConfig = AuditConfiguration::forEntities($this->auditedEntities);
+        $auditConfig->setGlobalIgnoreColumns(['ignoreme']);
+        $auditConfig->setWithForeignKeys(false);
+        $auditConfig->setUsernameCallable(static fn (): string => 'beberlei');
+
+        $this->auditManager = new AuditManager($auditConfig, $this->getClock());
+        $this->auditManager->registerEvents($this->getEntityManager()->getEventManager());
+
+        return $this->auditManager;
+    }
+}

--- a/tests/NoForeignKeysTest.php
+++ b/tests/NoForeignKeysTest.php
@@ -71,7 +71,7 @@ final class NoForeignKeysTest extends BaseTest
 
         $auditConfig = AuditConfiguration::forEntities($this->auditedEntities);
         $auditConfig->setGlobalIgnoreColumns(['ignoreme']);
-        $auditConfig->setWithForeignKeys(false);
+        $auditConfig->setDisabledForeignKeys(true);
         $auditConfig->setUsernameCallable(static fn (): string => 'beberlei');
 
         $this->auditManager = new AuditManager($auditConfig, $this->getClock());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Large legacy projects can contain a massive amount of audit data. Adding foreign keys can take a significant amount of time. I have added a 'with_foreign_keys' parameter, which can be used to disable the creation of foreign keys.

## Changelog

```markdown
### Added
Added the `disable_foreign_keys` parameter, which disables the creation of foreign keys.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
