### PR TITLE
Fix "diff" result for dates and other objects

### DIFF
--- a/src/Utils/ArrayDiff.php
+++ b/src/Utils/ArrayDiff.php
@@ -55,8 +55,10 @@ class ArrayDiff
      * Compare the type and the property values of two objects.
      * Return true if they are the same, false otherwise.
      * If the type is the same and all properties are the same, this will return true, even if they are not the same instance.
+     * This method is different from comparing two objects using ==,
+     * because internally the strict comparison operator (===) is used to compare the properties.
      *
-     * @see https://www.php.net/manual/en/language.oop5.object-comparison.php.
+     * @see https://www.php.net/manual/en/language.oop5.object-comparison.php
      */
     private function compareObjects(object $object1, object $object2): bool
     {

--- a/src/Utils/ArrayDiff.php
+++ b/src/Utils/ArrayDiff.php
@@ -55,13 +55,13 @@ class ArrayDiff
      * Compare the type and the property values of two objects.
      * Return true if they are the same, false otherwise.
      * If the type is the same and all properties are the same, this will return true, even if they are not the same instance.
+     *
+     * @see https://www.php.net/manual/en/language.oop5.object-comparison.php.
      */
-    public function compareObjects(object $object1, object $object2): bool
+    private function compareObjects(object $object1, object $object2): bool
     {
         // Check if the objects are of the same type.
-        $obj1Class = $object1::class;
-        $obj2Class = $object2::class;
-        if ($obj1Class !== $obj2Class) {
+        if ($object1::class !== $object2::class) {
             return false;
         }
 
@@ -76,6 +76,7 @@ class ArrayDiff
                 if (!$this->compareObjects($value, $obj2Properties[$key])) {
                     return false;
                 }
+
                 continue;
             }
             if ($value !== $obj2Properties[$key]) {

--- a/tests/Utils/ArrayDiffTest.php
+++ b/tests/Utils/ArrayDiffTest.php
@@ -16,7 +16,7 @@ namespace Sonata\EntityAuditBundle\Tests\Utils;
 use PHPUnit\Framework\TestCase;
 use SimpleThings\EntityAudit\Utils\ArrayDiff;
 
-class ArrayDiffTest extends TestCase
+final class ArrayDiffTest extends TestCase
 {
     public function testDiff(): void
     {

--- a/tests/Utils/ArrayDiffTest.php
+++ b/tests/Utils/ArrayDiffTest.php
@@ -74,6 +74,22 @@ final class ArrayDiffTest extends TestCase
         static::assertSame($expected, $result);
     }
 
+    public function testDiffDateSameButTimezoneDifferent(): void
+    {
+        $diff = new ArrayDiff();
+
+        $dateInstance1 = new \DateTimeImmutable('2014-01-01 00:00:00.000000', new \DateTimeZone('Europe/Luxembourg'));
+        $dateInstance2 = new \DateTimeImmutable('2014-01-01 00:00:00.000000', new \DateTimeZone('UTC'));
+
+        $array1 = ['date' => $dateInstance1];
+        $array2 = ['date' => $dateInstance2];
+        $expected = ['date' => ['old' => $dateInstance1, 'new' => $dateInstance2, 'same' => '']];
+
+        $result = $diff->diff($array1, $array2);
+
+        static::assertSame($expected, $result);
+    }
+
     public function testDiffObjectSame(): void
     {
         $diff = new ArrayDiff();

--- a/tests/Utils/ArrayDiffTest.php
+++ b/tests/Utils/ArrayDiffTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use SimpleThings\EntityAudit\Utils\ArrayDiff;
+
+class ArrayDiffTest extends TestCase
+{
+    public function testDiff(): void
+    {
+        $diff = new ArrayDiff();
+        $array1 = ['one' => 'I', 'two' => '2'];
+        $array2 = ['one' => 'I', 'two' => 'II'];
+        $expected = ['one' => ['old' => '', 'new' => '', 'same' => 'I'], 'two' => ['old' => '2', 'new' => 'II', 'same' => '']];
+
+        $result = $diff->diff($array1, $array2);
+
+        static::assertSame($expected, $result);
+    }
+
+    public function testDiffIsCaseSensitive(): void
+    {
+        $diff = new ArrayDiff();
+        $array1 = ['one' => 'I', 'two' => 'ii'];
+        $array2 = ['one' => 'I', 'two' => 'II'];
+        $expected = ['one' => ['old' => '', 'new' => '', 'same' => 'I'], 'two' => ['old' => 'ii', 'new' => 'II', 'same' => '']];
+
+        $result = $diff->diff($array1, $array2);
+
+        static::assertSame($expected, $result);
+    }
+
+    public function testDiffDate(): void
+    {
+        $diff = new ArrayDiff();
+
+        $dateInstance1 = new \DateTimeImmutable('2014-01-01 00:00:00.000000');
+        $dateInstance2 = new \DateTimeImmutable('2014-01-01 00:00:00.000000');
+
+        $array1 = ['date' => $dateInstance1];
+        $array2 = ['date' => $dateInstance2];
+        $expected = ['date' => ['old' => '', 'new' => '', 'same' => $dateInstance1]];
+
+        $result = $diff->diff($array1, $array2);
+
+        static::assertSame($expected, $result);
+    }
+
+    public function testDiffDateDifferent(): void
+    {
+        $diff = new ArrayDiff();
+
+        $dateInstance1 = new \DateTimeImmutable('2014-01-01 00:00:00.000000');
+        $dateInstance2 = new \DateTimeImmutable('2014-01-02 00:00:00.000000');
+
+        $array1 = ['date' => $dateInstance1];
+        $array2 = ['date' => $dateInstance2];
+        $expected = ['date' => ['old' => $dateInstance1, 'new' => $dateInstance2, 'same' => '']];
+
+        $result = $diff->diff($array1, $array2);
+
+        static::assertSame($expected, $result);
+    }
+
+    public function testDiffObjectSame(): void
+    {
+        $diff = new ArrayDiff();
+        $object1 = (object) ['one' => 'I', 'two' => 'II'];
+        $object2 = (object) ['one' => 'I', 'two' => 'II'];
+        $array1 = ['object' => $object1];
+        $array2 = ['object' => $object2];
+        $expected = ['object' => ['old' => '', 'new' => '', 'same' => $object1]];
+
+        $result = $diff->diff($array1, $array2);
+
+        static::assertSame($expected, $result);
+    }
+
+    public function testDiffObjectDifferent(): void
+    {
+        $diff = new ArrayDiff();
+        $object1 = (object) ['one' => 'I', 'two' => 'ii'];
+        $object2 = (object) ['one' => 'I', 'two' => 'II'];
+        $array1 = ['object' => $object1];
+        $array2 = ['object' => $object2];
+        $expected = ['object' => ['old' => $object1, 'new' => $object2, 'same' => '']];
+
+        $result = $diff->diff($array1, $array2);
+
+        static::assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
## Subject

This pull request fixes an issue with the ArrayDiff class and consequentially the AuditReader.

AuditReader::diff currently shows dates (instances of DateTime or DateTimeImmutable) as changed even though they are the same.

This issue was introduced when the loose comparator ("==") was changed to the strict comparison ("===") in commit [bf02fd4](https://github.com/sonata-project/EntityAuditBundle/commit/bf02fd49463c25f23f9d2e7755ec20eec8151733#diff-80e1d2d2d865a9b942c0d8c11dd827f4dcbe88352e95ac38f0079bd416caae68)

This PR reverts the old behaviour for objects, while keeping the strict comparison for other types.

I also added tests. Some of the tests fail without the change, so I hope this illustrates the issue.

I am targeting this branch, because this is a fix that restores previous behaviour (and slightly improves it).

## Changelog

```markdown
### Fixed
- Objects now no longer show as different when their values are the same. This restores some of the old behaviour of the EntityAuditBundle
```