### PR TITLE
Allow multiple relationships to a target entity.

### DIFF
--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -464,7 +464,8 @@ class LogRevisionsListener implements EventSubscriber
      */
     private function getInsertJoinTableRevisionSQL(ClassMetadata $class, ClassMetadata $targetClass, array $assoc): string
     {
-        $cacheKey = $class->name.'.'.$targetClass->name;
+        $cacheKey = $class->name.'.'.$targetClass->name.'.'.$assoc['joinTable']['name'];
+
         if (!isset($this->insertJoinTableRevisionSQL[$cacheKey])
             && isset($assoc['relationToSourceKeyColumns'], $assoc['relationToTargetKeyColumns'], $assoc['joinTable']['name'])) {
             $placeholders = ['?', '?'];

--- a/tests/Fixtures/Relation/ManyToManyMultipleRelationshipEntity.php
+++ b/tests/Fixtures/Relation/ManyToManyMultipleRelationshipEntity.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Relation;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class ManyToManyMultipleRelationshipEntity
+{
+    /**
+     * @var int|null
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    /**
+     * @var string|null
+     */
+    #[ORM\Column(type: Types::STRING)]
+    protected $title;
+
+    /**
+     * @var Collection<int, ManyToManyMultipleTargetEntity>
+     */
+    #[ORM\ManyToMany(targetEntity: ManyToManyMultipleTargetEntity::class)]
+    #[ORM\JoinTable(name: 'many_to_many_primary_target')]
+    protected $primaryTargets = [];
+
+    /**
+     * @var Collection<int, ManyToManyMultipleTargetEntity>
+     */
+    #[ORM\ManyToMany(targetEntity: ManyToManyMultipleTargetEntity::class)]
+    #[ORM\JoinTable(name: 'many_to_many_secondary_target')]
+    protected $secondaryTargets;
+
+    public function __construct()
+    {
+        $this->primaryTargets = new ArrayCollection();
+        $this->secondaryTargets = new ArrayCollection();
+    }
+
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getPrimaryTargets(): ArrayCollection|Collection|array
+    {
+        return $this->primaryTargets;
+    }
+
+    public function addPrimaryTarget(ManyToManyMultipleTargetEntity $target): void
+    {
+        $this->primaryTargets[] = $target;
+    }
+
+    public function getSecondaryTargets(): ArrayCollection|Collection
+    {
+        return $this->secondaryTargets;
+    }
+
+    public function addSecondaryTarget(ManyToManyMultipleTargetEntity $target): void
+    {
+        $this->secondaryTargets[] = $target;
+    }
+}

--- a/tests/Fixtures/Relation/ManyToManyMultipleTargetEntity.php
+++ b/tests/Fixtures/Relation/ManyToManyMultipleTargetEntity.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Relation;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class ManyToManyMultipleTargetEntity
+{
+    /**
+     * @var int|null
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+}

--- a/tests/RelationTest.php
+++ b/tests/RelationTest.php
@@ -22,6 +22,8 @@ use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\DataContainerEntity;
 use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\DataLegalEntity;
 use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\DataPrivateEntity;
 use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\FoodCategory;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\ManyToManyMultipleRelationshipEntity;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\ManyToManyMultipleTargetEntity;
 use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\OneToOneAuditedEntity;
 use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\OneToOneMasterEntity;
 use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\OneToOneNotAuditedEntity;
@@ -65,6 +67,8 @@ final class RelationTest extends BaseTest
         DataLegalEntity::class,
         DataPrivateEntity::class,
         DataContainerEntity::class,
+        ManyToManyMultipleRelationshipEntity::class,
+        ManyToManyMultipleTargetEntity::class,
     ];
 
     protected $auditedEntities = [
@@ -87,6 +91,8 @@ final class RelationTest extends BaseTest
         DataLegalEntity::class,
         DataPrivateEntity::class,
         DataContainerEntity::class,
+        ManyToManyMultipleRelationshipEntity::class,
+        ManyToManyMultipleTargetEntity::class,
     ];
 
     public function testUndefinedIndexesInUOWForRelations(): void
@@ -356,6 +362,44 @@ final class RelationTest extends BaseTest
         // checking the getOwnedInverse returns a collection of current owned4 entities
         static::assertInstanceOf(Collection::class, $audited->getOwnedInverse());
         static::assertCount(1, $audited->getOwnedInverse());
+    }
+
+
+    public function testManyToManyMultipleRelationshipSameTargetEntity(): void
+    {
+        $em = $this->getEntityManager();
+        $auditReader = $this->getAuditManager()->createAuditReader($em);
+
+        // create an entity that has multiple many-to-many relationships to the same target entity.
+
+        $targetOne = new ManyToManyMultipleTargetEntity();
+        $targetTwo = new ManyToManyMultipleTargetEntity();
+
+        $manyToMany = new ManyToManyMultipleRelationshipEntity();
+        $manyToMany->setTitle('manyToMany#1');
+        $manyToMany->addPrimaryTarget($targetOne);
+        $manyToMany->addSecondaryTarget($targetTwo);
+
+        $em->persist($targetOne);
+        $em->persist($targetTwo);
+        $em->persist($manyToMany);
+
+        $em->flush(); // #1
+
+        $manyToManyId = $manyToMany->getId();
+        static::assertNotNull($manyToManyId);
+
+        $audited = $auditReader->find(ManyToManyMultipleRelationshipEntity::class, $manyToManyId, 1);
+
+        static::assertNotNull($audited);
+
+        // ensure that there is an audited entry for the primaryTargets property
+        static::assertInstanceOf(Collection::class, $audited->getPrimaryTargets());
+        static::assertCount(1, $audited->getPrimaryTargets());
+
+        // ensure that there is an audited entry for the secondaryTargets property
+        static::assertInstanceOf(Collection::class, $audited->getSecondaryTargets());
+        static::assertCount(1, $audited->getSecondaryTargets());
     }
 
     /**

--- a/tests/RelationTest.php
+++ b/tests/RelationTest.php
@@ -364,7 +364,6 @@ final class RelationTest extends BaseTest
         static::assertCount(1, $audited->getOwnedInverse());
     }
 
-
     public function testManyToManyMultipleRelationshipSameTargetEntity(): void
     {
         $em = $this->getEntityManager();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

A cache key including the join table name fixes the issue where multiple many-to-many relationships to the same associated entity throws a Duplicate Key exception.  This occurs because cache key was only storing the entity class name and target entity class name.  

Closes #614.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
Allow multiple relationships to the same target entity.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
