### PR TITLE
Fix getting table name when the table schema is an empty string

### DIFF
--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -74,7 +74,7 @@ class AuditConfiguration
     {
         $tableName = $metadata->getTableName();
 
-        if (null !== $metadata->getSchemaName()) {
+        if (null !== $metadata->getSchemaName() && '' !== $metadata->getSchemaName()) {
             $tableName = $metadata->getSchemaName().'.'.$tableName;
         }
 

--- a/tests/AuditConfigurationTest.php
+++ b/tests/AuditConfigurationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
+use SimpleThings\EntityAudit\AuditConfiguration;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Core\ArticleAudit;
+
+final class AuditConfigurationTest extends TestCase
+{
+    public function testItReturnsCorrectTableNameWhenTableSchemaIsNull(): void
+    {
+        $auditConfig = new AuditConfiguration();
+
+        $metadata = new ClassMetadata(ArticleAudit::class);
+        $metadata->setPrimaryTable([
+            'name' => 'foo',
+            'schema' => null,
+        ]);
+
+        static::assertSame('foo_audit', $auditConfig->getTableName($metadata));
+    }
+
+    public function testItReturnsCorrectTableNameWhenTableSchemaIsEmptyString(): void
+    {
+        $auditConfig = new AuditConfiguration();
+
+        $metadata = new ClassMetadata(ArticleAudit::class);
+        $metadata->setPrimaryTable([
+            'name' => 'foo',
+            'schema' => '',
+        ]);
+
+        static::assertSame('foo_audit', $auditConfig->getTableName($metadata));
+    }
+
+    public function testItReturnsCorrectTableNameWhenTableSchemaIsSet(): void
+    {
+        $auditConfig = new AuditConfiguration();
+
+        $metadata = new ClassMetadata(ArticleAudit::class);
+        $metadata->setPrimaryTable([
+            'name' => 'foo',
+            'schema' => 'xyz',
+        ]);
+
+        static::assertSame('xyz.foo_audit', $auditConfig->getTableName($metadata));
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is bug fix.

Some bundles set the table schema to a blank string instead of `null` which then results in this bundle blowing up due to running broken SQL queries like `INSERT INTO .foo` (instead of `INSERT INTO foo`).

## Changelog

```markdown
### Fixed
Fix getting table name when the table schema is an empty string
```
