### PR TITLE
Replace EntityManager type-hint with EntityManagerInterface

### DIFF
--- a/src/AuditManager.php
+++ b/src/AuditManager.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace SimpleThings\EntityAudit;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
 use SimpleThings\EntityAudit\EventListener\CreateSchemaListener;
 use SimpleThings\EntityAudit\EventListener\LogRevisionsListener;
@@ -52,11 +52,9 @@ class AuditManager
     }
 
     /**
-     * NEXT_MAJOR: Use `\Doctrine\ORM\EntityManagerInterface` for argument 1.
-     *
      * @return AuditReader
      */
-    public function createAuditReader(EntityManager $em)
+    public function createAuditReader(EntityManagerInterface $em)
     {
         return new AuditReader($em, $this->config, $this->metadataFactory);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This PR fixes an issue when using an entity manager decorator (same as https://github.com/sonata-project/EntityAuditBundle/issues/149).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's BC (EntityManagerInterface was introduced in doctrine orm `2.4`, and version `^2.7` is required in `composer.json`.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Replaced AuditManager::createAuditReader(EntityManager $em) type-hint with EntityManagerInterface

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
