### PR TITLE
Added configuration option to disable auditing for object associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ simple_things_entity_audit:
     disable_foreign_keys: true
 ```
 
+If you want to disable auditing for object relations, you can use the `disable_associations` parameter:
+```yaml
+simple_things_entity_audit:
+    disable_associations: true
+```
+
 ### Creating new tables
 
 Call the command below to see the new tables in the update schema queue.
@@ -290,5 +296,5 @@ This provides you with a few different routes:
 ## TODOS
 
 * Currently only works with auto-increment databases
-* Proper metadata mapping is necessary, allow to disable versioning for fields and associations.
+* Proper metadata mapping is necessary, allow to disable versioning for fields.
 * It does NOT work with Joined-Table-Inheritance (Single Table Inheritance should work, but not tested)

--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -28,6 +28,8 @@ class AuditConfiguration
 
     private bool $disableForeignKeys = false;
 
+    private bool $disableAssociations = false;
+
     /**
      * @var string[]
      */
@@ -100,6 +102,16 @@ class AuditConfiguration
     public function setDisabledForeignKeys(bool $disabled): void
     {
         $this->disableForeignKeys = $disabled;
+    }
+
+    public function areAssociationsDisabled(): bool
+    {
+        return $this->disableAssociations;
+    }
+
+    public function setDisableAssociations(bool $disabled): void
+    {
+        $this->disableAssociations = $disabled;
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -53,6 +53,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('revision_type_field_name')->defaultValue('revtype')->end()
                 ->scalarNode('revision_table_name')->defaultValue('revisions')->end()
                 ->scalarNode('disable_foreign_keys')->defaultValue(false)->end()
+                ->scalarNode('disable_associations')->defaultValue(false)->end()
                 ->scalarNode('revision_id_field_type')
                     ->defaultValue(Types::INTEGER)
                     // NEXT_MAJOR: Use enumNode() instead.

--- a/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
+++ b/src/DependencyInjection/SimpleThingsEntityAuditExtension.php
@@ -40,6 +40,7 @@ class SimpleThingsEntityAuditExtension extends Extension
             'revision_id_field_type',
             'global_ignore_columns',
             'disable_foreign_keys',
+            'disable_associations',
         ];
 
         foreach ($configurables as $key) {

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -107,6 +107,14 @@ class CreateSchemaListener implements EventSubscriber
         $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionTable->getName()).'_idx';
         $revisionTable->addIndex([$this->config->getRevisionFieldName()], $revIndexName);
 
+        if (!$this->config->areForeignKeysDisabled()) {
+            $this->createForeignKeys($revisionTable, $revisionsTable);
+        }
+
+        if ($this->config->areAssociationsDisabled()) {
+            return;
+        }
+
         foreach ($cm->associationMappings as $associationMapping) {
             if ($associationMapping['isOwningSide'] && isset($associationMapping['joinTable'])) {
                 if (isset($associationMapping['joinTable']['name'])) {
@@ -117,10 +125,6 @@ class CreateSchemaListener implements EventSubscriber
                     }
                 }
             }
-        }
-
-        if (!$this->config->areForeignKeysDisabled()) {
-            $this->createForeignKeys($revisionTable, $revisionsTable);
         }
     }
 

--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -198,6 +198,10 @@ class LogRevisionsListener implements EventSubscriber
             $em->getConnection()->executeQuery($sql, $params, $types);
         }
 
+        if ($this->config->areAssociationsDisabled()) {
+            return;
+        }
+
         foreach ($this->deferredChangedManyToManyEntityRevisionsToPersist as $deferredChangedManyToManyEntityRevisionToPersist) {
             $this->recordRevisionForManyToManyEntity(
                 $deferredChangedManyToManyEntityRevisionToPersist->getEntity(),
@@ -568,7 +572,7 @@ class LogRevisionsListener implements EventSubscriber
                             $types[] = $targetClass->getTypeOfField($targetClass->getFieldForColumn($targetColumn));
                         }
                     }
-                } elseif (($assoc['type'] & ClassMetadata::MANY_TO_MANY) > 0
+                } elseif (!$this->config->areAssociationsDisabled() && ($assoc['type'] & ClassMetadata::MANY_TO_MANY) > 0
                     && isset($assoc['relationToSourceKeyColumns'], $assoc['relationToTargetKeyColumns'])) {
                     $targetClass = $em->getClassMetadata($assoc['targetEntity']);
 
@@ -646,6 +650,8 @@ class LogRevisionsListener implements EventSubscriber
      * @param array<string, mixed>  $entityData
      * @param ClassMetadata<object> $class
      * @param ClassMetadata<object> $targetClass
+     *
+     * @throws Exception
      */
     private function recordRevisionForManyToManyEntity(object $relatedEntity, EntityManagerInterface $em, string $revType, array $entityData, array $assoc, ClassMetadata $class, ClassMetadata $targetClass): void
     {

--- a/src/Resources/config/auditable.php
+++ b/src/Resources/config/auditable.php
@@ -49,7 +49,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('simplethings.entityaudit.revision_id_field_type', null)
 
-        ->set('simplethings.entityaudit.disable_foreign_keys', null);
+        ->set('simplethings.entityaudit.disable_foreign_keys', null)
+
+        ->set('simplethings.entityaudit.disable_associations', false);
 
     $containerConfigurator->services()
         ->set('simplethings_entityaudit.manager', AuditManager::class)
@@ -129,6 +131,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->call('setRevisionIdFieldType', [param('simplethings.entityaudit.revision_id_field_type')])
             ->call('setRevisionFieldName', [param('simplethings.entityaudit.revision_field_name')])
             ->call('setRevisionTypeFieldName', [param('simplethings.entityaudit.revision_type_field_name')])
+            ->call('setDisableAssociations', [param('simplethings.entityaudit.disable_associations')])
             ->call('setUsernameCallable', [service('simplethings_entityaudit.username_callable')])
             ->alias(AuditConfiguration::class, 'simplethings_entityaudit.config');
 };

--- a/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
+++ b/tests/DependencyInjection/SimpleThingsEntityAuditExtensionTest.php
@@ -79,6 +79,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionFieldName', ['%simplethings.entityaudit.revision_field_name%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setRevisionTypeFieldName', ['%simplethings.entityaudit.revision_type_field_name%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setDisabledForeignKeys', ['%simplethings.entityaudit.disable_foreign_keys%']);
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setDisableAssociations', ['%simplethings.entityaudit.disable_associations%']);
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('simplethings_entityaudit.config', 'setUsernameCallable', ['simplethings_entityaudit.username_callable']);
     }
 
@@ -121,6 +122,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_type_field_name', 'revtype');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_id_field_type', Types::INTEGER);
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.disable_foreign_keys', false);
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.disable_associations', false);
     }
 
     public function testItSetsConfiguredParameters(): void
@@ -137,6 +139,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
             'revision_field_name' => 'revision',
             'revision_type_field_name' => 'action',
             'disable_foreign_keys' => false,
+            'disable_associations' => true,
         ]);
 
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.connection', 'my_custom_connection');
@@ -150,6 +153,7 @@ final class SimpleThingsEntityAuditExtensionTest extends AbstractExtensionTestCa
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_field_name', 'revision');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.revision_type_field_name', 'action');
         $this->assertContainerBuilderHasParameter('simplethings.entityaudit.disable_foreign_keys', false);
+        $this->assertContainerBuilderHasParameter('simplethings.entityaudit.disable_associations', true);
 
         foreach ([Events::onFlush, Events::postPersist, Events::postUpdate, Events::postFlush, Events::onClear] as $event) {
             $this->assertContainerBuilderHasServiceDefinitionWithTag('simplethings_entityaudit.log_revisions_listener', 'doctrine.event_listener', ['event' => $event, 'connection' => 'my_custom_connection']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Pull request allows you to globally disable building a database scheme, and attempt to audit object relationships

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - 2.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/EntityAuditBundle/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it is a new feature.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #601.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- New configuration option `disable_associations` to disable association tracking.
