### PR TITLE
Bugfix, field type definitions in LogRevisionsListener

### DIFF
--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -133,7 +133,7 @@ class LogRevisionsListener implements EventSubscriber
                 if ($meta->hasField($fieldName)) {
                     /** @phpstan-var literal-string $field */
                     $field = $quoteStrategy->getColumnName($field, $meta, $platform);
-                    $fieldType = $meta->getTypeOfField($field);
+                    $fieldType = $meta->getTypeOfField($fieldName);
                     if (null !== $fieldType) {
                         $type = Type::getType($fieldType);
                         /** @phpstan-var literal-string $placeholder */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixes an error in determining the column type when the entity field name differs from the column name in DB.
Due to this error, conversion rules for custom Doctrine types are not applied.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/EntityAuditBundle/releases,
    please keep it short and clear and to the point
-->

```markdown
### Fixed
- Fixed an error in determining the column type

```