### PR TITLE
Add support for doctrine/dbal 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.1",
         "doctrine/collections": "^1.8 || ^2.0",
-        "doctrine/dbal": "^3.6",
+        "doctrine/dbal": "^3.6 || ^4.0",
         "doctrine/event-manager": "^1.2 || ^2.0",
         "doctrine/orm": "^2.14 || ^3.0",
         "doctrine/persistence": "^3.0",

--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -297,7 +297,7 @@ class AuditReader
                 $allDiscrValues = array_flip($classMetadata->discriminatorMap);
                 $queriedDiscrValues = [$this->em->getConnection()->quote($classMetadata->discriminatorValue)];
                 foreach ($classMetadata->subClasses as $subclassName) {
-                    $queriedDiscrValues[] = $this->em->getConnection()->quote($allDiscrValues[$subclassName]);
+                    $queriedDiscrValues[] = $this->em->getConnection()->quote((string) $allDiscrValues[$subclassName]);
                 }
 
                 $whereSQL .= \sprintf(

--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -15,8 +15,12 @@ namespace SimpleThings\EntityAudit\EventListener;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Name\Identifier;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -26,6 +30,7 @@ use Doctrine\ORM\Tools\ToolEvents;
 use SimpleThings\EntityAudit\AuditConfiguration;
 use SimpleThings\EntityAudit\AuditManager;
 use SimpleThings\EntityAudit\Metadata\MetadataFactory;
+use SimpleThings\EntityAudit\Utils\DbalCompatibilityTrait;
 use SimpleThings\EntityAudit\Utils\ORMCompatibilityTrait;
 
 /**
@@ -36,6 +41,7 @@ use SimpleThings\EntityAudit\Utils\ORMCompatibilityTrait;
  */
 class CreateSchemaListener implements EventSubscriber
 {
+    use DbalCompatibilityTrait;
     use ORMCompatibilityTrait;
 
     private AuditConfiguration $config;
@@ -95,9 +101,13 @@ class CreateSchemaListener implements EventSubscriber
         $revisionsTable = $this->createRevisionsTable($schema);
 
         $entityTable = $eventArgs->getClassTable();
-        $revisionTable = $schema->createTable(
-            $this->config->getTablePrefix().$entityTable->getName().$this->config->getTableSuffix()
-        );
+        if ($this->isDbal4_3()) {
+            $tableName = $this->config->getTablePrefix().$entityTable->getObjectName()->toString().$this->config->getTableSuffix();
+        } else {
+            /** @psalm-suppress InternalMethod */
+            $tableName = $this->config->getTablePrefix().$entityTable->getName().$this->config->getTableSuffix(); // @phpstan-ignore-line
+        }
+        $revisionTable = $schema->createTable($tableName);
 
         foreach ($entityTable->getColumns() as $column) {
             $this->addColumnToTable($column, $revisionTable);
@@ -105,15 +115,33 @@ class CreateSchemaListener implements EventSubscriber
         $revisionTable->addColumn($this->config->getRevisionFieldName(), $this->config->getRevisionIdFieldType());
         $revisionTable->addColumn($this->config->getRevisionTypeFieldName(), Types::STRING, ['length' => 4]);
         if (!\in_array($cm->inheritanceType, [ClassMetadata::INHERITANCE_TYPE_NONE, ClassMetadata::INHERITANCE_TYPE_JOINED, ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE], true)) {
-            throw new \Exception(\sprintf('Inheritance type "%s" is not yet supported', $cm->inheritanceType));
+            throw new \RuntimeException(\sprintf('Inheritance type "%s" is not yet supported', $cm->inheritanceType));
         }
 
-        $primaryKey = $entityTable->getPrimaryKey();
-        \assert(null !== $primaryKey);
-        $pkColumns = $primaryKey->getColumns();
-        $pkColumns[] = $this->config->getRevisionFieldName();
-        $revisionTable->setPrimaryKey($pkColumns);
-        $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionTable->getName()).'_idx';
+        if ($this->isDbal4_3()) {
+            $primaryKey = $entityTable->getPrimaryKeyConstraint();
+            \assert(null !== $primaryKey);
+            $pkColumns = $primaryKey->getColumnNames();
+            /** @psalm-suppress ArgumentTypeCoercion */
+            $pkColumns[] = new UnqualifiedName(Identifier::unquoted($this->config->getRevisionFieldName())); // @phpstan-ignore-line
+            $editor = PrimaryKeyConstraint::editor()->setColumnNames(...$pkColumns)->setIsClustered($primaryKey->isClustered());
+            $revisionTable->addPrimaryKeyConstraint($editor->create());
+        } else {
+            /** @psalm-suppress DeprecatedMethod */
+            $primaryKey = $entityTable->getPrimaryKey();
+            \assert(null !== $primaryKey);
+            /** @psalm-suppress DeprecatedMethod */
+            $pkColumns = $primaryKey->getColumns();
+            $pkColumns[] = $this->config->getRevisionFieldName();
+            /** @psalm-suppress DeprecatedMethod */
+            $revisionTable->setPrimaryKey($pkColumns);
+        }
+        if ($this->isDbal4_3()) {
+            $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionTable->getObjectName()->toString()).'_idx';
+        } else {
+            /** @psalm-suppress InternalMethod */
+            $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionTable->getName()).'_idx'; // @phpstan-ignore-line
+        }
         $revisionTable->addIndex([$this->config->getRevisionFieldName()], $revIndexName);
 
         foreach ($cm->associationMappings as $associationMapping) {
@@ -143,17 +171,48 @@ class CreateSchemaListener implements EventSubscriber
 
     private function createForeignKeys(Table $relatedTable, Table $revisionsTable): void
     {
-        $revisionForeignKeyName = $this->config->getRevisionFieldName().'_'.md5($relatedTable->getName()).'_fk';
-        $primaryKey = $revisionsTable->getPrimaryKey();
-        \assert(null !== $primaryKey);
-
-        $relatedTable->addForeignKeyConstraint(
-            $revisionsTable,
-            [$this->config->getRevisionFieldName()],
-            $primaryKey->getColumns(),
-            [],
-            $revisionForeignKeyName
-        );
+        if ($this->isDbal4_3()) {
+            $revisionForeignKeyName = $this->config->getRevisionFieldName().'_'.md5($relatedTable->getObjectName()->toString()).'_fk';
+            $primaryKey = $revisionsTable->getPrimaryKeyConstraint();
+            \assert(null !== $primaryKey);
+            $relatedTable->addForeignKeyConstraint(
+                $revisionsTable->getObjectName()->toString(),
+                [$this->config->getRevisionFieldName()],
+                array_map(static fn (UnqualifiedName $name) => $name->toString(), $primaryKey->getColumnNames()),
+                [],
+                $revisionForeignKeyName
+            );
+        } elseif ($this->isDbal4()) {
+            /** @psalm-suppress InternalMethod */
+            $revisionForeignKeyName = $this->config->getRevisionFieldName().'_'.md5($relatedTable->getName()).'_fk'; // @phpstan-ignore-line
+            /** @psalm-suppress DeprecatedMethod */
+            $primaryKey = $revisionsTable->getPrimaryKey();
+            \assert(null !== $primaryKey);
+            /** @psalm-suppress InternalMethod */
+            /** @psalm-suppress DeprecatedMethod */
+            $relatedTable->addForeignKeyConstraint(
+                $revisionsTable->getName(), // @phpstan-ignore-line
+                [$this->config->getRevisionFieldName()],
+                $primaryKey->getColumns(),
+                [],
+                $revisionForeignKeyName
+            );
+        } else {
+            /** @psalm-suppress InternalMethod */
+            $revisionForeignKeyName = $this->config->getRevisionFieldName().'_'.md5($relatedTable->getName()).'_fk'; // @phpstan-ignore-line
+            /** @psalm-suppress DeprecatedMethod */
+            $primaryKey = $revisionsTable->getPrimaryKey();
+            \assert(null !== $primaryKey);
+            /** @psalm-suppress DeprecatedMethod */
+            /** @psalm-suppress InvalidArgument */
+            $relatedTable->addForeignKeyConstraint(
+                $revisionsTable, // @phpstan-ignore-line doctrine/dbal 3 support for old addForeignKeyConstraint() signature
+                [$this->config->getRevisionFieldName()],
+                $primaryKey->getColumns(),
+                [],
+                $revisionForeignKeyName
+            );
+        }
     }
 
     /**
@@ -161,7 +220,12 @@ class CreateSchemaListener implements EventSubscriber
      */
     private function addColumnToTable(Column $column, Table $targetTable): void
     {
-        $columnName = $column->getName();
+        if ($this->isDbal4_3()) {
+            $columnName = $column->getObjectName()->toString();
+        } else {
+            /** @psalm-suppress InternalMethod */
+            $columnName = $column->getName(); // @phpstan-ignore-line
+        }
 
         $targetTable->addColumn(
             $columnName,
@@ -175,9 +239,16 @@ class CreateSchemaListener implements EventSubscriber
         $targetColumn->setUnsigned($column->getUnsigned());
         $targetColumn->setFixed($column->getFixed());
         $targetColumn->setDefault($column->getDefault());
-        $targetColumn->setColumnDefinition($column->getColumnDefinition());
+        if ('' !== $column->getColumnDefinition()) {
+            $targetColumn->setColumnDefinition($column->getColumnDefinition());
+        }
         $targetColumn->setComment($column->getComment());
-        $targetColumn->setPlatformOptions($column->getPlatformOptions());
+        if ($this->isDbal4_3()) {
+            $targetColumn->setPlatformOptions(['charset' => $column->getCharset(), 'collation' => $column->getCollation()]);
+        } else {
+            /** @psalm-suppress DeprecatedMethod */
+            $targetColumn->setPlatformOptions($column->getPlatformOptions());
+        }
 
         $targetColumn->setNotnull(false);
         $targetColumn->setAutoincrement(false);
@@ -196,8 +267,15 @@ class CreateSchemaListener implements EventSubscriber
             'autoincrement' => true,
         ]);
         $revisionsTable->addColumn('timestamp', Types::DATETIME_MUTABLE);
-        $revisionsTable->addColumn('username', Types::STRING)->setNotnull(false);
-        $revisionsTable->setPrimaryKey(['id']);
+        $revisionsTable->addColumn('username', Types::STRING, ['length' => 255])->setNotnull(false);
+        if ($this->isDbal4_3()) {
+            $id = new UnqualifiedName(Identifier::unquoted('id'));
+            $editor = PrimaryKeyConstraint::editor()->setColumnNames($id)->setIsClustered(true);
+            $revisionsTable->addPrimaryKeyConstraint($editor->create());
+        } else {
+            /** @psalm-suppress DeprecatedMethod */
+            $revisionsTable->setPrimaryKey(['id']);
+        }
 
         return $revisionsTable;
     }
@@ -205,32 +283,63 @@ class CreateSchemaListener implements EventSubscriber
     private function createRevisionJoinTableForJoinTable(Schema $schema, string $joinTableName): void
     {
         $joinTable = $schema->getTable($joinTableName);
-        $revisionJoinTableName = $this->config->getTablePrefix().$joinTable->getName().$this->config->getTableSuffix();
+        if ($this->isDbal4_3()) {
+            $revisionJoinTableName = $this->config->getTablePrefix().$joinTable->getObjectName()->toString().$this->config->getTableSuffix();
+        } else {
+            /** @psalm-suppress InternalMethod */
+            $revisionJoinTableName = $this->config->getTablePrefix().$joinTable->getName().$this->config->getTableSuffix(); // @phpstan-ignore-line
+        }
 
         if ($schema->hasTable($revisionJoinTableName)) {
             return;
         }
 
         $typeRegistry = Type::getTypeRegistry();
-        $revisionJoinTable = $schema->createTable(
-            $this->config->getTablePrefix().$joinTable->getName().$this->config->getTableSuffix()
-        );
+        if ($this->isDbal4_3()) {
+            $tableName = $this->config->getTablePrefix().$joinTable->getObjectName()->toString().$this->config->getTableSuffix();
+        } else {
+            /** @psalm-suppress InternalMethod */
+            $tableName = $this->config->getTablePrefix().$joinTable->getName().$this->config->getTableSuffix(); // @phpstan-ignore-line
+        }
+        $revisionJoinTable = $schema->createTable($tableName);
+        /** @var Column $column */
         foreach ($joinTable->getColumns() as $column) {
-            /* @var Column $column */
-            $revisionJoinTable->addColumn(
-                $column->getName(),
-                $typeRegistry->lookupName($column->getType()),
-                ['notnull' => false, 'autoincrement' => false]
-            );
+            $options = ['notnull' => false, 'autoincrement' => false];
+            if ($column->getType() instanceof StringType) {
+                $options['length'] = $column->getLength();
+            }
+            if ($this->isDbal4_3()) {
+                $revisionJoinTable->addColumn($column->getObjectName()->toString(), $typeRegistry->lookupName($column->getType()), $options);
+            } else {
+                /** @psalm-suppress InternalMethod */
+                $revisionJoinTable->addColumn($column->getName(), $typeRegistry->lookupName($column->getType()), $options); // @phpstan-ignore-line
+            }
         }
         $revisionJoinTable->addColumn($this->config->getRevisionFieldName(), $this->config->getRevisionIdFieldType());
         $revisionJoinTable->addColumn($this->config->getRevisionTypeFieldName(), 'string', ['length' => 4]);
 
-        $pk = $joinTable->getPrimaryKey();
-        $pkColumns = null !== $pk ? $pk->getColumns() : [];
-        $pkColumns[] = $this->config->getRevisionFieldName();
-        $revisionJoinTable->setPrimaryKey($pkColumns);
-        $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionJoinTable->getName()).'_idx';
+        if ($this->isDbal4_3()) {
+            $pk = $joinTable->getPrimaryKeyConstraint();
+            $pkColumns = null !== $pk ? $pk->getColumnNames() : [];
+            /** @psalm-suppress ArgumentTypeCoercion */
+            $pkColumns[] = new UnqualifiedName(Identifier::unquoted($this->config->getRevisionFieldName())); // @phpstan-ignore-line
+            $editor = PrimaryKeyConstraint::editor()->setColumnNames(...$pkColumns)->setIsClustered(!(null !== $pk) || $pk->isClustered());
+            $revisionJoinTable->addPrimaryKeyConstraint($editor->create());
+        } else {
+            /** @psalm-suppress DeprecatedMethod */
+            $pk = $joinTable->getPrimaryKey();
+            /** @psalm-suppress DeprecatedMethod */
+            $pkColumns = null !== $pk ? $pk->getColumns() : [];
+            $pkColumns[] = $this->config->getRevisionFieldName();
+            /** @psalm-suppress DeprecatedMethod */
+            $revisionJoinTable->setPrimaryKey($pkColumns);
+        }
+        if ($this->isDbal4_3()) {
+            $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionJoinTable->getObjectName()->toString()).'_idx';
+        } else {
+            /** @psalm-suppress InternalMethod */
+            $revIndexName = $this->config->getRevisionFieldName().'_'.md5($revisionJoinTable->getName()).'_idx'; // @phpstan-ignore-line
+        }
         $revisionJoinTable->addIndex([$this->config->getRevisionFieldName()], $revIndexName);
     }
 }

--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -16,6 +16,7 @@ namespace SimpleThings\EntityAudit\EventListener;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
@@ -35,6 +36,7 @@ use SimpleThings\EntityAudit\AuditConfiguration;
 use SimpleThings\EntityAudit\AuditManager;
 use SimpleThings\EntityAudit\DeferredChangedManyToManyEntityRevisionToPersist;
 use SimpleThings\EntityAudit\Metadata\MetadataFactory;
+use SimpleThings\EntityAudit\Utils\DbalCompatibilityTrait;
 use SimpleThings\EntityAudit\Utils\ORMCompatibilityTrait;
 
 /**
@@ -45,6 +47,7 @@ use SimpleThings\EntityAudit\Utils\ORMCompatibilityTrait;
  */
 class LogRevisionsListener implements EventSubscriber
 {
+    use DbalCompatibilityTrait;
     use ORMCompatibilityTrait;
 
     private AuditConfiguration $config;
@@ -169,7 +172,7 @@ class LogRevisionsListener implements EventSubscriber
                     }
 
                     if (null === $type) {
-                        throw new \Exception(\sprintf('Could not resolve database type for column "%s" during extra updates', $column));
+                        throw new \RuntimeException(\sprintf('Could not resolve database type for column "%s" during extra updates', $column));
                     }
 
                     $types[] = $type;
@@ -186,7 +189,11 @@ class LogRevisionsListener implements EventSubscriber
                     $types[] = self::getMappingValue($meta->fieldMappings[$idField], 'type');
                 } elseif (isset($meta->associationMappings[$idField]['joinColumns'])) {
                     $columnName = self::getMappingNameValue($meta->associationMappings[$idField]['joinColumns'][0]);
-                    $types[] = $meta->associationMappings[$idField]['type'];
+                    if ($this->isDbal4()) {
+                        $types[] = ParameterType::STRING;
+                    } else {
+                        $types[] = $meta->associationMappings[$idField]['type'];
+                    }
                 } else {
                     throw new \RuntimeException('column name not found  for'.$idField);
                 }
@@ -198,6 +205,7 @@ class LogRevisionsListener implements EventSubscriber
                 $sql .= ' AND '.$columnName.' = ?';
             }
 
+            /** @psalm-suppress InvalidArgument for doctrine/dbal 3 type can be integer */
             $em->getConnection()->executeQuery($sql, $params, $types);
         }
 
@@ -383,7 +391,11 @@ class LogRevisionsListener implements EventSubscriber
             );
 
             $revisionId = $conn->lastInsertId();
-            if (false === $revisionId) {
+            /*
+             * NEXT_MAJOR: Remove this `if` block, because lastInsertId throws an exception in DBAL 4
+             */
+            /** @psalm-suppress TypeDoesNotContainType */
+            if (false === $revisionId) { // @phpstan-ignore-line doctrine/dbal 3 lastInsertId() can return false
                 throw new \RuntimeException('Unable to retrieve the last revision id.');
             }
 
@@ -451,7 +463,7 @@ class LogRevisionsListener implements EventSubscriber
 
             if (
                 (
-                    $class->isInheritanceTypeJoined() && $class->rootEntityName === $class->name
+                    ($class->isInheritanceTypeJoined() && $class->rootEntityName === $class->name)
                     || $class->isInheritanceTypeSingleTable()
                 )
                 && null !== $class->discriminatorColumn
@@ -523,7 +535,11 @@ class LogRevisionsListener implements EventSubscriber
         $conn = $em->getConnection();
 
         $params = [$this->getRevisionId($conn), $revType];
-        $types = [\PDO::PARAM_INT, \PDO::PARAM_STR];
+        if ($this->isDbal4()) {
+            $types = [ParameterType::INTEGER, ParameterType::STRING];
+        } else {
+            $types = [\PDO::PARAM_INT, \PDO::PARAM_STR];
+        }
 
         $fields = [];
 
@@ -547,7 +563,11 @@ class LogRevisionsListener implements EventSubscriber
                         $fields[$sourceColumn] = true;
                         if (null === $data) {
                             $params[] = null;
-                            $types[] = \PDO::PARAM_STR;
+                            if ($this->isDbal4()) {
+                                $types[] = ParameterType::STRING;
+                            } else {
+                                $types[] = \PDO::PARAM_STR;
+                            }
                         } else {
                             $params[] = $relatedId[$targetClass->fieldNames[$targetColumn]] ?? null;
                             $types[] = $targetClass->getTypeOfField($targetClass->getFieldForColumn($targetColumn));
@@ -622,6 +642,7 @@ class LogRevisionsListener implements EventSubscriber
             }
         }
 
+        /** @psalm-suppress InvalidArgument for doctrine/dbal 3 type can be integer */
         $conn->executeStatement($this->getInsertRevisionSQL($em, $class), $params, $types);
     }
 
@@ -642,7 +663,11 @@ class LogRevisionsListener implements EventSubscriber
     ): void {
         $conn = $em->getConnection();
         $joinTableParams = [$this->getRevisionId($conn), $revType];
-        $joinTableTypes = [\PDO::PARAM_INT, \PDO::PARAM_STR];
+        if ($this->isDbal4()) {
+            $joinTableTypes = [ParameterType::INTEGER, ParameterType::STRING];
+        } else {
+            $joinTableTypes = [\PDO::PARAM_INT, \PDO::PARAM_STR];
+        }
 
         foreach (self::getRelationToSourceKeyColumns($assoc) as $targetColumn) {
             $joinTableParams[] = $entityData[$class->fieldNames[$targetColumn]];
@@ -655,10 +680,11 @@ class LogRevisionsListener implements EventSubscriber
             $joinTableParams[] = $reflField->getValue($relatedEntity);
             $joinTableTypes[] = PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $em);
         }
+        /** @psalm-suppress InvalidArgument for doctrine/dbal 3 type can be integer */
         $conn->executeStatement(
             $this->getInsertJoinTableRevisionSQL($class, $targetClass, $assoc),
             $joinTableParams,
-            $joinTableTypes
+            $joinTableTypes // @phpstan-ignore-line for doctrine/dbal 3 type can be integer
         );
     }
 

--- a/src/Utils/DbalCompatibilityTrait.php
+++ b/src/Utils/DbalCompatibilityTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SimpleThings\EntityAudit\Utils;
+
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+
+/**
+ * NEXT_MAJOR: remove this trait and all `if` blocks.
+ *
+ * @internal
+ */
+trait DbalCompatibilityTrait
+{
+    protected function isDbal4_3(): bool
+    {
+        return class_exists(UnqualifiedName::class); // @phpstan-ignore-line class added in doctrine/dbal 4.3
+    }
+
+    protected function isDbal4(): bool
+    {
+        return is_subclass_of(ParameterType::class, \UnitEnum::class); // @phpstan-ignore-line class changed to enum in doctrine/dbal 4
+    }
+}

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -17,6 +17,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Tools\DsnParser;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
@@ -126,7 +127,8 @@ abstract class BaseTest extends TestCase
         if (!isset(self::$conn)) {
             $url = getenv('DATABASE_URL');
             if (false !== $url) {
-                $params = ['url' => $url];
+                $dsnParser = new DsnParser(['mysql' => 'pdo_mysql', 'postgresql' => 'pdo_pgsql']);
+                $params = $dsnParser->parse($url);
             } else {
                 $params = [
                     'driver' => 'pdo_sqlite',

--- a/tests/CoreTest.php
+++ b/tests/CoreTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\EntityAuditBundle\Tests;
 
 use Doctrine\DBAL\Exception\DriverException;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use SimpleThings\EntityAudit\ChangedEntity;
 use SimpleThings\EntityAudit\Exception\NoRevisionFoundException;
 use SimpleThings\EntityAudit\Exception\NotAuditedException;
@@ -485,7 +485,7 @@ final class CoreTest extends BaseTest
     {
         $em = $this->getEntityManager();
 
-        $isSqlitePlatform = $em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform;
+        $isSqlitePlatform = $em->getConnection()->getDatabasePlatform() instanceof SQLitePlatform;
         $updateForeignKeysConfig = false;
 
         if ($isSqlitePlatform) {

--- a/tests/Issue/Issue318Test.php
+++ b/tests/Issue/Issue318Test.php
@@ -38,13 +38,11 @@ final class Issue318Test extends BaseTest
         $userMetadata = $em->getClassMetadata($user::class);
         $classes = [$userMetadata];
         $schema = $this->getSchemaTool()->getSchemaFromMetadata($classes);
-        $schemaName = $schema->getName();
         $config = $this->getAuditManager()->getConfiguration();
         $userNotNullColumnName = 'alias';
         $userIdColumnName = 'id';
         $revisionsTableUser = $schema->getTable(\sprintf(
-            '%s.%sissue318user%s',
-            $schemaName,
+            '%sissue318user%s',
             $config->getTablePrefix(),
             $config->getTableSuffix()
         ));

--- a/tests/RelationTest.php
+++ b/tests/RelationTest.php
@@ -1010,7 +1010,7 @@ final class RelationTest extends BaseTest
 
     /**
      * Specific test for the case where a join condition is via an ORM/Id and where the column is also an object.
-     * Used to result in an 'aray to string conversion' error.
+     * Used to result in an 'array to string conversion' error.
      *
      * @doesNotPerformAssertions
      */

--- a/tests/Types/ConvertToPHPType.php
+++ b/tests/Types/ConvertToPHPType.php
@@ -28,11 +28,18 @@ final class ConvertToPHPType extends TextType
         return true;
     }
 
+    /**
+     * @param string           $sqlExpr
+     * @param AbstractPlatform $platform
+     */
     public function convertToPHPValueSQL($sqlExpr, $platform): string
     {
         return \sprintf('UPPER(%s)', $sqlExpr);
     }
 
+    /**
+     * @param string $sqlExpr
+     */
     public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform): string
     {
         return \sprintf('LOWER(%s)', $sqlExpr);

--- a/tests/Types/Issue196Type.php
+++ b/tests/Types/Issue196Type.php
@@ -31,6 +31,9 @@ final class Issue196Type extends TextType
         return true;
     }
 
+    /**
+     * @param string $sqlExpr
+     */
     public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform): string
     {
         return \sprintf('lower(%s)', $sqlExpr);


### PR DESCRIPTION

## Subject
I am targeting this branch, because this patch is backwards compatible.

While adding support for Doctrine DBAL 4, I encountered a bug during testing: when creating audit tables for @JoinTable associations, the length parameter is not respected if the primary key is a string. In my case, the country table has a primary key of type CHAR(2). With DBAL 3, the audit table was created with a column of type VARCHAR(255). In DBAL 4, however, an exception is thrown because string columns now require an explicit length. I’ve fixed this issue.
I then tested this branch on my project using both DBAL 3 and DBAL 4, and everything is working as expected.

Closes #636.

## Changelog
```markdown
### Added
- Support for doctrine/dbal 4

### Fixed
- Creating of Join Audit tables with string primary keys
```
