### PR TITLE
Fix for non-existing revision in many-to-many association

### DIFF
--- a/src/AuditReader.php
+++ b/src/AuditReader.php
@@ -1070,7 +1070,12 @@ class AuditReader
                                     $joinKey = $row[$targetKeyJoinColumn];
                                     $id[$targetKeyColumn] = $joinKey;
                                 }
-                                $object = $this->find($targetClass->getName(), $id, $revision);
+                                try {
+                                    $object = $this->find($targetClass->getName(), $id, $revision);
+                                } catch (NoRevisionFoundException) {
+                                    // The entity does not have any revision yet. So let's get the actual state of it.
+                                    $object = $this->em->getRepository($targetClass->getName())->findOneBy($id);
+                                }
                                 if (null !== $object) {
                                     $collection->add($object);
                                 }
@@ -1155,7 +1160,12 @@ class AuditReader
                                     $id[$sourceKeyColumn] = $joinKey;
                                 }
 
-                                $object = $this->find($targetClass->getName(), $id, $revision);
+                                try {
+                                    $object = $this->find($targetClass->getName(), $id, $revision);
+                                } catch (NoRevisionFoundException) {
+                                    // The entity does not have any revision yet. So let's get the actual state of it.
+                                    $object = $this->em->getRepository($targetClass->getName())->findOneBy($id);
+                                }
                                 if (null !== $object) {
                                     $collection->add($object);
                                 }

--- a/src/Collection/AuditedCollection.php
+++ b/src/Collection/AuditedCollection.php
@@ -323,9 +323,10 @@ class AuditedCollection implements Collection
     }
 
     /**
+     * @phpstan-template U
+     *
      * @return Collection<TKey, U>
      *
-     * @phpstan-template U
      * @phpstan-param \Closure(T):U $func
      * @phpstan-return Collection<TKey, U>
      */

--- a/src/Collection/AuditedCollection.php
+++ b/src/Collection/AuditedCollection.php
@@ -323,10 +323,9 @@ class AuditedCollection implements Collection
     }
 
     /**
-     * @phpstan-template U
-     *
      * @return Collection<TKey, U>
      *
+     * @phpstan-template U
      * @phpstan-param \Closure(T):U $func
      * @phpstan-return Collection<TKey, U>
      */

--- a/tests/Fixtures/Relation/Company.php
+++ b/tests/Fixtures/Relation/Company.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Relation;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
+#[ORM\Entity]
+class Company
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    protected ?int $id = null;
+
+    #[ORM\Column(length: 40)]
+    protected ?string $name = null;
+
+    /**
+     * @var Collection<int, DocumentType>
+     */
+    #[ORM\ManyToMany(targetEntity: DocumentType::class, inversedBy: 'companies')]
+    #[ORM\JoinTable(name: 'company_document_types')]
+    #[ORM\JoinColumn(name: 'company_id')]
+    #[ORM\InverseJoinColumn(name: 'document_type_id')]
+    protected Collection $documentTypes;
+
+    public function __construct()
+    {
+        $this->documentTypes = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, DocumentType>
+     */
+    public function getDocumentTypes(): Collection
+    {
+        return $this->documentTypes;
+    }
+
+    public function addDocumentType(DocumentType $documentType): self
+    {
+        if (!$this->documentTypes->contains($documentType)) {
+            $this->documentTypes[] = $documentType;
+            $documentType->addCompany($this);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Relation/DocumentType.php
+++ b/tests/Fixtures/Relation/DocumentType.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Relation;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
+#[ORM\Entity]
+class DocumentType
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    protected ?int $id = null;
+
+    #[ORM\Column(length: 40)]
+    protected ?string $name = null;
+
+    /**
+     * @var Collection<int, Company>
+     */
+    #[ORM\ManyToMany(targetEntity: Company::class, mappedBy: 'documentTypes')]
+    private Collection $companies;
+
+    public function __construct()
+    {
+        $this->companies = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function addCompany(Company $company): void
+    {
+        if (!$this->companies->contains($company)) {
+            $this->companies[] = $company;
+            $company->addDocumentType($this);
+        }
+    }
+
+    /**
+     * @return Collection<int, Company>
+     */
+    public function getCompanies(): Collection
+    {
+        return $this->companies;
+    }
+}

--- a/tests/Issue/IssueNoRevisionManyToManyTest.php
+++ b/tests/Issue/IssueNoRevisionManyToManyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Issue;
+
+use Sonata\EntityAuditBundle\Tests\BaseTest;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\Company;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Relation\DocumentType;
+
+final class IssueNoRevisionManyToManyTest extends BaseTest
+{
+    protected $schemaEntities = [
+        Company::class,
+        DocumentType::class,
+    ];
+
+    protected $auditedEntities = [
+        Company::class,
+        DocumentType::class,
+    ];
+
+    public function testOwningSide(): void
+    {
+        $company = new Company();
+        $company->setName('Company');
+        $type = new DocumentType();
+        $type->setName('Type');
+        $company->addDocumentType($type);
+
+        $em = $this->getEntityManager();
+
+        $em->persist($company);
+        $em->persist($type);
+        $em->flush();
+
+        $em->getConnection()->executeQuery('DELETE FROM DocumentType_audit');
+
+        $manager = $this->getAuditManager();
+        $reader = $manager->createAuditReader($em);
+        $entity = $reader->find(Company::class, 1, 1);
+        // Exception NoRevisionFoundException wasn't thrown
+        static::assertInstanceOf(Company::class, $entity);
+    }
+
+    public function testInverseSide(): void
+    {
+        $company = new Company();
+        $company->setName('Company');
+        $type = new DocumentType();
+        $type->setName('Type');
+        $company->addDocumentType($type);
+
+        $em = $this->getEntityManager();
+
+        $em->persist($company);
+        $em->persist($type);
+        $em->flush();
+
+        $em->getConnection()->executeQuery('DELETE FROM Company_audit');
+
+        $manager = $this->getAuditManager();
+        $reader = $manager->createAuditReader($em);
+        $entity = $reader->find(DocumentType::class, 1, 1);
+        // Exception NoRevisionFoundException wasn't thrown
+        static::assertInstanceOf(DocumentType::class, $entity);
+    }
+}


### PR DESCRIPTION
## Subject

I am targeting this branch, because this patch is backwards compatible.

I found a bug when viewing the history of an entity that has ManyToMany associations. If a revision for the related entity cannot be found, a NoRevisionFoundException is thrown. In ToOne part of the code `if (self::isToOne($assoc)) {` - this exception is caught and the object is then loaded directly from the database. I added the same handling to the ManyToMany block, and now everything works correctly — in my project, all revisions are available for entities with ManyToMany relations.

## Changelog
```markdown
### Fixed
- NoRevisionFoundException when viewing history of entities with ManyToMany associations.
```