### PR TITLE
Fix unnecessary revision creation when only a column from the globalIgnoreColumns list is updated

### DIFF
--- a/src/EventListener/LogRevisionsListener.php
+++ b/src/EventListener/LogRevisionsListener.php
@@ -724,6 +724,10 @@ class LogRevisionsListener implements EventSubscriber
                 continue;
             }
 
+            if (\in_array($field, $this->config->getGlobalIgnoreColumns(), true)) {
+                continue;
+            }
+
             $newVal = $change[1];
 
             if (!isset($classMetadata->associationMappings[$field])) {

--- a/tests/Fixtures/Issue/IssueGlobalIgnoreColumnsEntity.php
+++ b/tests/Fixtures/Issue/IssueGlobalIgnoreColumnsEntity.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Issue;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
+#[ORM\Entity]
+class IssueGlobalIgnoreColumnsEntity
+{
+    /**
+     * @var int|null
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    private $id;
+
+    #[ORM\Column(type: Types::STRING)]
+    private ?string $ignoreme = null;
+
+    #[ORM\Column(type: Types::STRING)]
+    private ?string $name = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getIgnoreme(): ?string
+    {
+        return $this->ignoreme;
+    }
+
+    public function setIgnoreme(?string $ignoreme): self
+    {
+        $this->ignoreme = $ignoreme;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/Issue/IssueGlobalIgnoreColumns.php
+++ b/tests/Issue/IssueGlobalIgnoreColumns.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Issue;
+
+use Sonata\EntityAuditBundle\Tests\BaseTestCase;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Issue\IssueGlobalIgnoreColumnsEntity;
+
+final class IssueGlobalIgnoreColumns extends BaseTestCase
+{
+    protected $schemaEntities = [
+        IssueGlobalIgnoreColumnsEntity::class,
+    ];
+
+    protected $auditedEntities = [
+        IssueGlobalIgnoreColumnsEntity::class,
+    ];
+
+    public function testGlobalIgnoreColumns(): void
+    {
+        $entity = new IssueGlobalIgnoreColumnsEntity();
+        $entity->setIgnoreme('test1')
+            ->setName('name1');
+
+        $em = $this->getEntityManager();
+
+        $em->persist($entity);
+        $em->flush();
+        $em->clear();
+
+        $entityId = $entity->getId();
+        static::assertNotNull($entityId);
+
+        $persistedEntity = $em->find(IssueGlobalIgnoreColumnsEntity::class, $entityId);
+        static::assertNotNull($persistedEntity);
+
+        $this->getAuditManager();
+        $cnt = $em->getConnection()->executeQuery('SELECT COUNT(*) FROM revisions')->fetchOne();
+
+        $entity = $em->find(IssueGlobalIgnoreColumnsEntity::class, $entityId);
+        static::assertInstanceOf(IssueGlobalIgnoreColumnsEntity::class, $entity);
+        $entity->setIgnoreme('test2')->setName('name2');
+        $em->flush();
+        $em->clear();
+
+        $newCnt = $em->getConnection()->executeQuery('SELECT COUNT(*) FROM revisions')->fetchOne();
+        static::assertSame($cnt + 1, $newCnt);
+
+        $entity = $em->find(IssueGlobalIgnoreColumnsEntity::class, $entityId);
+        static::assertInstanceOf(IssueGlobalIgnoreColumnsEntity::class, $entity);
+        $entity->setIgnoreme('test2');
+        $em->flush();
+        $em->clear();
+
+        $newCnt = $em->getConnection()->executeQuery('SELECT COUNT(*) FROM revisions')->fetchOne();
+        static::assertSame($cnt + 1, $newCnt);
+    }
+}


### PR DESCRIPTION
## Subject

When only a column from the globalIgnoreColumns list is updated, a new revision is incorrectly created, and an update is attempted on a non-existent record in the audit table.

Example: last_login and updated_at are in globalIgnoreColumns, and the following SQL is executed:

```
UPDATE user SET last_login = ?, updated_at = ? WHERE id = ? (parameters: array{"1":"2026-03-24 14:14:40","2":"2026-03-24 14:14:40","3":4}, types: array{"1":0,"2":0,"3":0})
INSERT INTO revision (timestamp, username) VALUES (?, ?) (parameters: array{"1":"2026-03-24 14:14:40","2":""}, types: array{"1":0,"2":0}) 
UPDATE user_audit SET last_login = ?, updated_at = ? WHERE rev = ? AND id = ? (parameters: array{"1":"2026-03-24 14:14:40","2":"2026-03-24 14:14:40","3":"368","4":4}, types: array{"1":0,"2":0,"3":0,"4":0})
```

I added a check for globalIgnoreColumns, and now no new revision is created and no update is executed.

I am targeting this branch, because this fix is backwards compatible.

## Changelog

```markdown
### Fixed
Fix unnecessary revision creation when only a column from the globalIgnoreColumns list is updated
```