### PR TITLE
Update Rector config to use PHPUnit 11.0 set

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -34,7 +34,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_82,
-        PHPUnitSetList::PHPUNIT_100,
+        PHPUnitSetList::PHPUNIT_110,
         PHPUnitSetList::PHPUNIT_CODE_QUALITY,
     ]);
 


### PR DESCRIPTION

## Subject

Phpunit versions were bumped in November, but rector ruleset was not updated.

I am targeting this branch, because this fix is backwards compatible.
