### PR TITLE
Fix audit schema generation for reserved-keyword table names on DBAL 4.3+

### DIFF
--- a/src/EventListener/CreateSchemaListener.php
+++ b/src/EventListener/CreateSchemaListener.php
@@ -98,11 +98,7 @@ class CreateSchemaListener implements EventSubscriber
         $revisionsTable = $this->createRevisionsTable($schema);
 
         $entityTable = $eventArgs->getClassTable();
-        if ($this->isDbal4_3()) {
-            $tableName = $this->config->getTablePrefix().$entityTable->getObjectName()->toString().$this->config->getTableSuffix();
-        } else {
-            $tableName = $this->config->getTablePrefix().$entityTable->getName().$this->config->getTableSuffix(); // @phpstan-ignore-line
-        }
+        $tableName = $this->config->getTablePrefix().$this->getUnquotedTableName($entityTable).$this->config->getTableSuffix();
         $revisionTable = $schema->createTable($tableName);
 
         foreach ($entityTable->getColumns() as $column) {
@@ -263,22 +259,14 @@ class CreateSchemaListener implements EventSubscriber
     private function createRevisionJoinTableForJoinTable(Schema $schema, string $joinTableName): void
     {
         $joinTable = $schema->getTable($joinTableName);
-        if ($this->isDbal4_3()) {
-            $revisionJoinTableName = $this->config->getTablePrefix().$joinTable->getObjectName()->toString().$this->config->getTableSuffix();
-        } else {
-            $revisionJoinTableName = $this->config->getTablePrefix().$joinTable->getName().$this->config->getTableSuffix(); // @phpstan-ignore-line
-        }
+        $revisionJoinTableName = $this->config->getTablePrefix().$this->getUnquotedTableName($joinTable).$this->config->getTableSuffix();
 
         if ($schema->hasTable($revisionJoinTableName)) {
             return;
         }
 
         $typeRegistry = Type::getTypeRegistry();
-        if ($this->isDbal4_3()) {
-            $tableName = $this->config->getTablePrefix().$joinTable->getObjectName()->toString().$this->config->getTableSuffix();
-        } else {
-            $tableName = $this->config->getTablePrefix().$joinTable->getName().$this->config->getTableSuffix(); // @phpstan-ignore-line
-        }
+        $tableName = $revisionJoinTableName;
         $revisionJoinTable = $schema->createTable($tableName);
         /** @var Column $column */
         foreach ($joinTable->getColumns() as $column) {

--- a/src/Utils/DbalCompatibilityTrait.php
+++ b/src/Utils/DbalCompatibilityTrait.php
@@ -15,6 +15,7 @@ namespace SimpleThings\EntityAudit\Utils;
 
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
+use Doctrine\DBAL\Schema\Table;
 
 /**
  * NEXT_MAJOR: remove this trait and all `if` blocks.
@@ -26,6 +27,28 @@ trait DbalCompatibilityTrait
     protected function isDbal4_3(): bool
     {
         return class_exists(UnqualifiedName::class); // @phpstan-ignore-line class added in doctrine/dbal 4.3
+    }
+
+    /**
+     * Returns the unquoted name of a table, usable as a base for deriving a related
+     * table name through concatenation.
+     *
+     * On DBAL >= 4.3, Table::getName() is deprecated and Table::getObjectName()->toString()
+     * renders a *quoted* identifier for reserved keywords (e.g. `"user"`). Concatenating
+     * that with a prefix/suffix yields an unparseable name (`"user"_audit`), which DBAL
+     * leaves uninitialized and then rejects from getObjectName(). Using the raw identifier
+     * value preserves the historical (pre-4.3) behaviour.
+     */
+    protected function getUnquotedTableName(Table $table): string
+    {
+        if ($this->isDbal4_3()) {
+            $name = $table->getObjectName();
+            $qualifier = $name->getQualifier();
+
+            return (null !== $qualifier ? $qualifier->getValue().'.' : '').$name->getUnqualifiedName()->getValue();
+        }
+
+        return $table->getName(); // @phpstan-ignore-line
     }
 
     protected function isDbal4(): bool

--- a/tests/Fixtures/Issue/ReservedTableNameEntity.php
+++ b/tests/Fixtures/Issue/ReservedTableNameEntity.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Fixtures\Issue;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * The table name is an SQL reserved keyword, so it is force-quoted by Doctrine.
+ *
+ * @psalm-suppress ClassMustBeFinal
+ */
+#[ORM\Entity]
+#[ORM\Table(name: '`user`')]
+class ReservedTableNameEntity
+{
+    /**
+     * @var int|null
+     */
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\Column(type: Types::STRING, length: 255)]
+    private ?string $name = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name = null): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Issue/IssueReservedTableNameTest.php
+++ b/tests/Issue/IssueReservedTableNameTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\EntityAuditBundle\Tests\Issue;
+
+use Sonata\EntityAuditBundle\Tests\BaseTestCase;
+use Sonata\EntityAuditBundle\Tests\Fixtures\Issue\ReservedTableNameEntity;
+
+final class IssueReservedTableNameTest extends BaseTestCase
+{
+    protected $schemaEntities = [
+        ReservedTableNameEntity::class,
+    ];
+
+    protected $auditedEntities = [
+        ReservedTableNameEntity::class,
+    ];
+
+    /**
+     * On DBAL >= 4.3 the audit table name was derived from the *quoted* identifier
+     * (e.g. `"user"` + `_audit` => `"user"_audit`), which is not a parseable name, so
+     * schema generation crashed with "Object name has not been initialized".
+     */
+    public function testAuditSchemaForReservedKeywordTableName(): void
+    {
+        $entity = new ReservedTableNameEntity();
+        $entity->setName('foo');
+
+        $em = $this->getEntityManager();
+
+        $em->persist($entity);
+        $em->flush();
+
+        $reader = $this->getAuditManager()->createAuditReader($em);
+
+        $id = $entity->getId();
+        static::assertNotNull($id);
+
+        $audited = $reader->find(ReservedTableNameEntity::class, $id, 1);
+        static::assertSame('foo', $audited->getName());
+    }
+}


### PR DESCRIPTION
## Subject

On `doctrine/dbal >= 4.3`, audit schema generation crashes with `Doctrine\DBAL\Schema\Exception\InvalidState: Object name has not been initialized` for any audited entity whose table name is an SQL reserved keyword (and is therefore force-quoted).

`CreateSchemaListener` derives the audit table name from `$entityTable->getObjectName()->toString()`, which on DBAL >= 4.3 renders a **quoted** identifier for reserved keywords (e.g. `"user"`). Concatenating it with the configured table prefix/suffix yields `"user"_audit`, which is not a parseable identifier: DBAL silently leaves the new table's name uninitialized and then throws from `getObjectName()` on the next access (here, while building the revision index name).

The pre-4.3 code path used `Table::getName()` (which returns the *unquoted* name), so it was not affected.

This PR adds `DbalCompatibilityTrait::getUnquotedTableName()`, which on DBAL >= 4.3 returns the raw unquoted identifier value (`getObjectName()->getUnqualifiedName()->getValue()`, prefixed with the qualifier when present) and otherwise falls back to `Table::getName()`. It is used at the three audit-table-name derivation sites (the entity table and the many-to-many join tables), restoring the historical behaviour.

A regression test (`IssueReservedTableNameTest`, with an entity mapped to a reserved `` `user` `` table) reproduces the crash before the fix and passes after it. The full test suite, PHPStan, PHP-CS-Fixer and Rector all pass on `doctrine/dbal` 4.4.3.

I am targeting the `1.x` branch, because this is a backwards-compatible bug fix.

## Changelog

```markdown
### Fixed
- Crash during audit schema generation for entities whose table name is a reserved SQL keyword on `doctrine/dbal` 4.3+
```
